### PR TITLE
refactor(feature/deal): split shared deal UI to :common:ui

### DIFF
--- a/common/src/main/java/pm/bam/gamedeals/common/FlowExtensions.kt
+++ b/common/src/main/java/pm/bam/gamedeals/common/FlowExtensions.kt
@@ -1,6 +1,7 @@
 package pm.bam.gamedeals.common
 
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.FlowCollector
@@ -86,6 +87,21 @@ fun <T, R> Flow<T>.mapDelayAtLeast(delayMillis: Long, transformFunction: suspend
 
         return@transform emit(transformedTransformation)
     }
+
+
+/**
+ * Runs [block] and ensures the total elapsed wall-clock time is at least [delayMillis] before
+ * returning the result. If [block] completes faster than [delayMillis], suspends for the remainder.
+ *
+ * Useful for "minimum loading duration" UX where you want to avoid flashing a loading state too briefly.
+ */
+suspend inline fun <T> withMinimumDuration(delayMillis: Long, crossinline block: suspend () -> T): T = coroutineScope {
+    val before = System.currentTimeMillis()
+    val result = block()
+    val elapsed = System.currentTimeMillis() - before
+    if (elapsed < delayMillis) delay(delayMillis - elapsed)
+    result
+}
 
 
 /**

--- a/common/ui/build.gradle.kts
+++ b/common/ui/build.gradle.kts
@@ -55,6 +55,7 @@ dependencies {
     implementation(libs.androidx.appcompat)
     implementation(libs.material)
     implementation(libs.androidx.compose.navigation)
+    implementation(libs.androidx.compose.runtime)
 
     implementation(libs.androidx.ui)
     implementation(libs.androidx.ui.graphics)
@@ -63,11 +64,18 @@ dependencies {
     implementation(libs.androidx.compose.material3.window)
     implementation(libs.androidx.compose.material3.adaptive)
 
+    implementation(libs.coil)
+    implementation(libs.coil.compose)
+
     testImplementation(project(":testing"))
     testImplementation(libs.junit)
     testImplementation(libs.mockk)
     testImplementation(libs.coroutines.testing)
 
+    androidTestImplementation(libs.mockk.android)
     androidTestImplementation(libs.androidx.junit)
+    androidTestImplementation(libs.androidx.runner)
     androidTestImplementation(libs.androidx.espresso.core)
+    androidTestImplementation(libs.androidx.compose.junit4)
+    debugImplementation(libs.androidx.compose.test)
 }

--- a/common/ui/build.gradle.kts
+++ b/common/ui/build.gradle.kts
@@ -49,6 +49,8 @@ android {
 
 dependencies {
 
+    implementation(project(":logging"))
+    implementation(project(":common"))
     implementation(project(":domain"))
 
     implementation(libs.androidx.ktx)

--- a/common/ui/src/androidTest/java/pm/bam/gamedeals/common/ui/deal/DealBottomSheetTest.kt
+++ b/common/ui/src/androidTest/java/pm/bam/gamedeals/common/ui/deal/DealBottomSheetTest.kt
@@ -1,4 +1,4 @@
-package pm.bam.gamedeals.feature.deal.ui
+package pm.bam.gamedeals.common.ui.deal
 
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.test.assert
@@ -15,10 +15,10 @@ import io.mockk.mockk
 import io.mockk.verify
 import org.junit.Rule
 import org.junit.Test
+import pm.bam.gamedeals.common.ui.R
 import pm.bam.gamedeals.common.ui.theme.GameDealsTheme
 import pm.bam.gamedeals.domain.models.DealDetails
 import pm.bam.gamedeals.domain.models.Store
-import pm.bam.gamedeals.feature.deal.R
 
 class DealBottomSheetTest {
 

--- a/common/ui/src/main/java/pm/bam/gamedeals/common/ui/deal/DealBottomSheet.kt
+++ b/common/ui/src/main/java/pm/bam/gamedeals/common/ui/deal/DealBottomSheet.kt
@@ -1,4 +1,4 @@
-package pm.bam.gamedeals.feature.deal.ui
+package pm.bam.gamedeals.common.ui.deal
 
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Box
@@ -43,11 +43,11 @@ import pm.bam.gamedeals.common.ui.PreviewDealCheapestPrice
 import pm.bam.gamedeals.common.ui.PreviewDealDetails
 import pm.bam.gamedeals.common.ui.PreviewDealGameInfo
 import pm.bam.gamedeals.common.ui.PreviewStore
+import pm.bam.gamedeals.common.ui.R
 import pm.bam.gamedeals.common.ui.theme.GameDealsCustomTheme
 import pm.bam.gamedeals.common.ui.theme.GameDealsTheme
 import pm.bam.gamedeals.domain.models.DealDetails
 import pm.bam.gamedeals.domain.models.Store
-import pm.bam.gamedeals.feature.deal.R
 
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -86,7 +86,7 @@ private fun DealContent(
             AsyncImage(
                 model = data.store.images.logo,
                 contentDescription = stringResource(R.string.deal_details_store_thumbnail, data.store.storeName),
-                error = painterResource(id = pm.bam.gamedeals.common.ui.R.drawable.videogame_thumb),
+                error = painterResource(id = R.drawable.videogame_thumb),
                 contentScale = ContentScale.Fit,
                 modifier = Modifier
                     .size(48.dp)
@@ -180,7 +180,7 @@ private fun GameDetails(
                         AsyncImage(
                             model = it.first.images.logo,
                             contentDescription = stringResource(R.string.deal_details_cheaper_store_thumbnail, data.store.storeName),
-                            error = painterResource(id = pm.bam.gamedeals.common.ui.R.drawable.videogame_thumb),
+                            error = painterResource(id = R.drawable.videogame_thumb),
                             contentScale = ContentScale.Fit,
                             modifier = Modifier
                                 .size(32.dp)
@@ -233,7 +233,7 @@ private fun GameDetails(
                 AsyncImage(
                     model = data.gameInfo.thumb,
                     contentDescription = stringResource(R.string.deal_details_game_image, data.gameName),
-                    error = painterResource(id = pm.bam.gamedeals.common.ui.R.drawable.videogame_thumb),
+                    error = painterResource(id = R.drawable.videogame_thumb),
                     contentScale = ContentScale.Fit,
                     modifier = Modifier
                         .fillMaxWidth()
@@ -396,7 +396,7 @@ private fun DealBottomErrorPreview() {
     }
 }
 
-internal const val DEAL_URL = "https://www.cheapshark.com/redirect?dealID="
+const val DEAL_URL = "https://www.cheapshark.com/redirect?dealID="
 
 internal const val CheapestPriceTag = "CheapestPrice"
 internal const val DataLoadingTag = "DataLoading"

--- a/common/ui/src/main/java/pm/bam/gamedeals/common/ui/deal/DealDetailsController.kt
+++ b/common/ui/src/main/java/pm/bam/gamedeals/common/ui/deal/DealDetailsController.kt
@@ -1,0 +1,74 @@
+package pm.bam.gamedeals.common.ui.deal
+
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+import pm.bam.gamedeals.common.withMinimumDuration
+import pm.bam.gamedeals.domain.repositories.deals.DealsRepository
+import pm.bam.gamedeals.domain.repositories.stores.StoresRepository
+import pm.bam.gamedeals.logging.Logger
+import pm.bam.gamedeals.logging.fatal
+
+class DealDetailsController(
+    private val dealsRepository: DealsRepository,
+    private val storesRepository: StoresRepository,
+    private val logger: Logger,
+) {
+    private val _dealDetails = MutableStateFlow<DealBottomSheetData?>(null)
+    val dealDetails: StateFlow<DealBottomSheetData?> = _dealDetails.asStateFlow()
+
+    fun load(
+        scope: CoroutineScope,
+        dealId: String,
+        dealStoreId: Int,
+        dealTitle: String,
+        dealPriceDenominated: String,
+    ): Job = scope.launch {
+        try {
+            _dealDetails.emit(
+                DealBottomSheetData.DealDetailsLoading(
+                    store = storesRepository.getStore(dealStoreId),
+                    gameName = dealTitle,
+                    dealId = dealId,
+                    gameSalesPriceDenominated = dealPriceDenominated,
+                )
+            )
+
+            val data = withMinimumDuration(750L) {
+                val dealDetails = dealsRepository.getDeal(dealId)
+                val store = storesRepository.getStore(dealStoreId)
+
+                DealBottomSheetData.DealDetailsData(
+                    store = store,
+                    gameName = dealTitle,
+                    dealId = dealId,
+                    gameSalesPriceDenominated = dealPriceDenominated,
+                    gameInfo = dealDetails.gameInfo,
+                    cheapestPrice = dealDetails.cheapestPrice,
+                    cheaperStores = dealDetails.cheaperStores.map { storesRepository.getStore(it.storeID) to it },
+                )
+            }
+            _dealDetails.emit(data)
+        } catch (t: Throwable) {
+            fatal(logger, t)
+            try {
+                _dealDetails.emit(
+                    DealBottomSheetData.DealDetailsError(
+                        store = storesRepository.getStore(dealStoreId),
+                        gameName = dealTitle,
+                        dealId = dealId,
+                        gameSalesPriceDenominated = dealPriceDenominated,
+                    )
+                )
+            } catch (inner: Throwable) {
+                fatal(logger, inner)
+                _dealDetails.emit(null)
+            }
+        }
+    }
+
+    fun dismiss(scope: CoroutineScope): Job = scope.launch { _dealDetails.emit(null) }
+}

--- a/common/ui/src/main/res/values/strings.xml
+++ b/common/ui/src/main/res/values/strings.xml
@@ -2,8 +2,6 @@
 <resources>
 
     <string name="deal_details_go_to_deal_label">Go to Deal</string>
-    <string name="deal_details_go_metacritic_label">Metacritic</string>
-    <string name="deal_details_go_wiki_label">Wiki</string>
 
     <string name="deal_details_game_image">%1$s Game image</string>
     <string name="deal_details_store_thumbnail">%1$s Store thumbnail</string>

--- a/feature/deal/src/main/java/pm/bam/gamedeals/feature/deal/ui/DealDetailsViewModel.kt
+++ b/feature/deal/src/main/java/pm/bam/gamedeals/feature/deal/ui/DealDetailsViewModel.kt
@@ -14,6 +14,7 @@ import kotlinx.coroutines.launch
 import pm.bam.gamedeals.common.logFlow
 import pm.bam.gamedeals.common.mapDelayAtLeast
 import pm.bam.gamedeals.common.onError
+import pm.bam.gamedeals.common.ui.deal.DealBottomSheetData
 import pm.bam.gamedeals.domain.repositories.deals.DealsRepository
 import pm.bam.gamedeals.domain.repositories.stores.StoresRepository
 import pm.bam.gamedeals.logging.Logger

--- a/feature/deal/src/test/java/pm/bam/gamedeals/feature/deal/ui/DealDetailsViewModelTest.kt
+++ b/feature/deal/src/test/java/pm/bam/gamedeals/feature/deal/ui/DealDetailsViewModelTest.kt
@@ -11,6 +11,7 @@ import org.junit.Assert.assertNull
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
+import pm.bam.gamedeals.common.ui.deal.DealBottomSheetData
 import pm.bam.gamedeals.domain.models.Deal
 import pm.bam.gamedeals.domain.models.DealDetails
 import pm.bam.gamedeals.domain.models.Store

--- a/feature/home/build.gradle.kts
+++ b/feature/home/build.gradle.kts
@@ -62,7 +62,6 @@ dependencies {
     implementation(project(":domain"))
     implementation(project(":common"))
     implementation(project(":common:ui"))
-    implementation(project(":feature:deal"))
 
     implementation(libs.androidx.ktx)
     implementation(libs.androidx.appcompat)

--- a/feature/home/src/androidTest/java/pm/bam/gamedeals/feature/home/ui/HomeScreenTest.kt
+++ b/feature/home/src/androidTest/java/pm/bam/gamedeals/feature/home/ui/HomeScreenTest.kt
@@ -20,7 +20,6 @@ import org.junit.Rule
 import org.junit.Test
 import pm.bam.gamedeals.domain.models.Deal
 import pm.bam.gamedeals.domain.models.Store
-import pm.bam.gamedeals.feature.deal.ui.DealDetailsViewModel
 import pm.bam.gamedeals.feature.home.R
 import pm.bam.gamedeals.feature.home.ui.HomeViewModel.HomeScreenData
 import pm.bam.gamedeals.feature.home.ui.HomeViewModel.HomeScreenListData
@@ -37,8 +36,6 @@ class HomeScreenTest {
     private val viewModel: HomeViewModel = mockk {
         every { events } returns MutableSharedFlow<HomeViewModel.HomeUiEvent>().asSharedFlow()
     }
-
-    private val dealDealDetailsViewModel: DealDetailsViewModel = mockk()
 
     private val storeId = 1
     private val storeTitle = "StoreTitle"
@@ -75,7 +72,7 @@ class HomeScreenTest {
 
     @Before
     fun setup() {
-        every { dealDealDetailsViewModel.dealDealDetails } returns MutableStateFlow(null)
+        every { viewModel.dealDetails } returns MutableStateFlow(null)
     }
 
     @Test
@@ -91,8 +88,7 @@ class HomeScreenTest {
                 onViewStoreDeals = {},
                 onViewGiveaways = {},
                 goToWeb = { _, _ -> },
-                viewModel = viewModel,
-                dealDealDetailsViewModel = dealDealDetailsViewModel
+                viewModel = viewModel
             )
         }
 
@@ -128,8 +124,7 @@ class HomeScreenTest {
                 onViewStoreDeals = {},
                 onViewGiveaways = {},
                 goToWeb = { _, _ -> },
-                viewModel = viewModel,
-                dealDealDetailsViewModel = dealDealDetailsViewModel
+                viewModel = viewModel
             )
         }
 
@@ -165,8 +160,7 @@ class HomeScreenTest {
                 onViewStoreDeals = {},
                 onViewGiveaways = {},
                 goToWeb = { _, _ -> },
-                viewModel = viewModel,
-                dealDealDetailsViewModel = dealDealDetailsViewModel
+                viewModel = viewModel
             )
         }
 

--- a/feature/home/src/main/java/pm/bam/gamedeals/feature/home/ui/HomeScreen.kt
+++ b/feature/home/src/main/java/pm/bam/gamedeals/feature/home/ui/HomeScreen.kt
@@ -58,15 +58,14 @@ import pm.bam.gamedeals.common.ui.PreviewRelease
 import pm.bam.gamedeals.common.ui.PreviewStore
 import pm.bam.gamedeals.common.ui.TabletLandscape
 import pm.bam.gamedeals.common.ui.TabletPortrait
+import pm.bam.gamedeals.common.ui.deal.DealBottomSheet
+import pm.bam.gamedeals.common.ui.deal.DealBottomSheetData
 import pm.bam.gamedeals.common.ui.theme.GameDealsCustomTheme
 import pm.bam.gamedeals.common.ui.theme.GameDealsTheme
 import pm.bam.gamedeals.domain.models.Deal
 import pm.bam.gamedeals.domain.models.Giveaway
 import pm.bam.gamedeals.domain.models.Release
 import pm.bam.gamedeals.domain.models.Store
-import pm.bam.gamedeals.feature.deal.ui.DealBottomSheet
-import pm.bam.gamedeals.feature.deal.ui.DealBottomSheetData
-import pm.bam.gamedeals.feature.deal.ui.DealDetailsViewModel
 import pm.bam.gamedeals.feature.home.R
 import pm.bam.gamedeals.feature.home.ui.HomeViewModel.HomeScreenListData.DealData
 import pm.bam.gamedeals.feature.home.ui.HomeViewModel.HomeScreenListData.StoreData
@@ -82,11 +81,10 @@ internal fun HomeScreen(
     onViewStoreDeals: ((store: Store) -> Unit) = {},
     onViewGiveaways: () -> Unit,
     goToWeb: (url: String, gameTitle: String) -> Unit,
-    viewModel: HomeViewModel = hiltViewModel(),
-    dealDealDetailsViewModel: DealDetailsViewModel = hiltViewModel()
+    viewModel: HomeViewModel = hiltViewModel()
 ) {
     val data = viewModel.uiState.collectAsStateWithLifecycle()
-    val dealDetails = dealDealDetailsViewModel.dealDealDetails.collectAsStateWithLifecycle()
+    val dealDetails = viewModel.dealDetails.collectAsStateWithLifecycle()
 
     val onReleaseTitle: (title: String) -> Unit = { title -> viewModel.onReleaseGame(title) }
 
@@ -96,7 +94,7 @@ internal fun HomeScreen(
         data = data.value,
         dealDetails = dealDetails.value,
         onViewDealDetails = { dealId, dealStoreId, dealTitle, dealPriceDenominated ->
-            dealDealDetailsViewModel.loadDealDetails(
+            viewModel.loadDealDetails(
                 dealId = dealId,
                 dealStoreId = dealStoreId,
                 dealTitle = dealTitle,
@@ -105,7 +103,7 @@ internal fun HomeScreen(
         },
         onViewStoreDeals = onViewStoreDeals,
         onViewGiveaways = onViewGiveaways,
-        onDismissDealDetails = { dealDealDetailsViewModel.dismissDealDetails() },
+        onDismissDealDetails = { viewModel.dismissDealDetails() },
         goToWeb = goToWeb,
         onRetry = { viewModel.loadTopStoresDeals() }
     )

--- a/feature/home/src/main/java/pm/bam/gamedeals/feature/home/ui/HomeViewModel.kt
+++ b/feature/home/src/main/java/pm/bam/gamedeals/feature/home/ui/HomeViewModel.kt
@@ -23,6 +23,8 @@ import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 import pm.bam.gamedeals.common.logFlow
 import pm.bam.gamedeals.common.onError
+import pm.bam.gamedeals.common.ui.deal.DealBottomSheetData
+import pm.bam.gamedeals.common.withMinimumDuration
 import pm.bam.gamedeals.domain.models.Deal
 import pm.bam.gamedeals.domain.models.Giveaway
 import pm.bam.gamedeals.domain.models.Release
@@ -56,6 +58,13 @@ internal class HomeViewModel @Inject constructor(
         scope = viewModelScope,
         started = SharingStarted.WhileSubscribed(5000),
         initialValue = HomeScreenData()
+    )
+
+    private val _dealDetails = MutableStateFlow<DealBottomSheetData?>(null)
+    val dealDetails: StateFlow<DealBottomSheetData?> = _dealDetails.stateIn(
+        scope = viewModelScope,
+        started = SharingStarted.WhileSubscribed(5000),
+        initialValue = null
     )
 
     private val _events = MutableSharedFlow<HomeUiEvent>(
@@ -94,6 +103,63 @@ internal class HomeViewModel @Inject constructor(
                 }
                 .collect { _events.emit(HomeUiEvent.NavigateToGame(it)) }
         }
+
+    fun loadDealDetails(
+        dealId: String,
+        dealStoreId: Int,
+        dealTitle: String,
+        dealPriceDenominated: String
+    ) {
+        viewModelScope.launch {
+            try {
+                _dealDetails.emit(
+                    DealBottomSheetData.DealDetailsLoading(
+                        store = storesRepository.getStore(dealStoreId),
+                        gameName = dealTitle,
+                        dealId = dealId,
+                        gameSalesPriceDenominated = dealPriceDenominated
+                    )
+                )
+
+                val data = withMinimumDuration(750L) {
+                    val dealDetails = dealsRepository.getDeal(dealId)
+                    val store = storesRepository.getStore(dealStoreId)
+
+                    DealBottomSheetData.DealDetailsData(
+                        store = store,
+                        gameName = dealTitle,
+                        dealId = dealId,
+                        gameSalesPriceDenominated = dealPriceDenominated,
+                        gameInfo = dealDetails.gameInfo,
+                        cheapestPrice = dealDetails.cheapestPrice,
+                        cheaperStores = dealDetails.cheaperStores.map { storesRepository.getStore(it.storeID) to it }
+                    )
+                }
+                _dealDetails.emit(data)
+            } catch (t: Throwable) {
+                fatal(logger, t)
+                try {
+                    _dealDetails.emit(
+                        DealBottomSheetData.DealDetailsError(
+                            store = storesRepository.getStore(dealStoreId),
+                            gameName = dealTitle,
+                            dealId = dealId,
+                            gameSalesPriceDenominated = dealPriceDenominated
+                        )
+                    )
+                } catch (inner: Throwable) {
+                    fatal(logger, inner)
+                    dismissDealDetails()
+                }
+            }
+        }
+    }
+
+    fun dismissDealDetails() {
+        viewModelScope.launch {
+            _dealDetails.emit(null)
+        }
+    }
 
     private fun loadTopStoreDataFlow() =
         flow { emitAll(storesRepository.observeStores()) }

--- a/feature/home/src/main/java/pm/bam/gamedeals/feature/home/ui/HomeViewModel.kt
+++ b/feature/home/src/main/java/pm/bam/gamedeals/feature/home/ui/HomeViewModel.kt
@@ -24,7 +24,7 @@ import kotlinx.coroutines.launch
 import pm.bam.gamedeals.common.logFlow
 import pm.bam.gamedeals.common.onError
 import pm.bam.gamedeals.common.ui.deal.DealBottomSheetData
-import pm.bam.gamedeals.common.withMinimumDuration
+import pm.bam.gamedeals.common.ui.deal.DealDetailsController
 import pm.bam.gamedeals.domain.models.Deal
 import pm.bam.gamedeals.domain.models.Giveaway
 import pm.bam.gamedeals.domain.models.Release
@@ -60,12 +60,8 @@ internal class HomeViewModel @Inject constructor(
         initialValue = HomeScreenData()
     )
 
-    private val _dealDetails = MutableStateFlow<DealBottomSheetData?>(null)
-    val dealDetails: StateFlow<DealBottomSheetData?> = _dealDetails.stateIn(
-        scope = viewModelScope,
-        started = SharingStarted.WhileSubscribed(5000),
-        initialValue = null
-    )
+    private val dealDetailsController = DealDetailsController(dealsRepository, storesRepository, logger)
+    val dealDetails: StateFlow<DealBottomSheetData?> = dealDetailsController.dealDetails
 
     private val _events = MutableSharedFlow<HomeUiEvent>(
         replay = 0,
@@ -104,61 +100,12 @@ internal class HomeViewModel @Inject constructor(
                 .collect { _events.emit(HomeUiEvent.NavigateToGame(it)) }
         }
 
-    fun loadDealDetails(
-        dealId: String,
-        dealStoreId: Int,
-        dealTitle: String,
-        dealPriceDenominated: String
-    ) {
-        viewModelScope.launch {
-            try {
-                _dealDetails.emit(
-                    DealBottomSheetData.DealDetailsLoading(
-                        store = storesRepository.getStore(dealStoreId),
-                        gameName = dealTitle,
-                        dealId = dealId,
-                        gameSalesPriceDenominated = dealPriceDenominated
-                    )
-                )
-
-                val data = withMinimumDuration(750L) {
-                    val dealDetails = dealsRepository.getDeal(dealId)
-                    val store = storesRepository.getStore(dealStoreId)
-
-                    DealBottomSheetData.DealDetailsData(
-                        store = store,
-                        gameName = dealTitle,
-                        dealId = dealId,
-                        gameSalesPriceDenominated = dealPriceDenominated,
-                        gameInfo = dealDetails.gameInfo,
-                        cheapestPrice = dealDetails.cheapestPrice,
-                        cheaperStores = dealDetails.cheaperStores.map { storesRepository.getStore(it.storeID) to it }
-                    )
-                }
-                _dealDetails.emit(data)
-            } catch (t: Throwable) {
-                fatal(logger, t)
-                try {
-                    _dealDetails.emit(
-                        DealBottomSheetData.DealDetailsError(
-                            store = storesRepository.getStore(dealStoreId),
-                            gameName = dealTitle,
-                            dealId = dealId,
-                            gameSalesPriceDenominated = dealPriceDenominated
-                        )
-                    )
-                } catch (inner: Throwable) {
-                    fatal(logger, inner)
-                    dismissDealDetails()
-                }
-            }
-        }
+    fun loadDealDetails(dealId: String, dealStoreId: Int, dealTitle: String, dealPriceDenominated: String) {
+        dealDetailsController.load(viewModelScope, dealId, dealStoreId, dealTitle, dealPriceDenominated)
     }
 
     fun dismissDealDetails() {
-        viewModelScope.launch {
-            _dealDetails.emit(null)
-        }
+        dealDetailsController.dismiss(viewModelScope)
     }
 
     private fun loadTopStoreDataFlow() =

--- a/feature/store/build.gradle.kts
+++ b/feature/store/build.gradle.kts
@@ -55,7 +55,6 @@ dependencies {
     implementation(project(":domain"))
     implementation(project(":common"))
     implementation(project(":common:ui"))
-    implementation(project(":feature:deal"))
 
     implementation(libs.androidx.ktx)
     implementation(libs.androidx.appcompat)

--- a/feature/store/src/androidTest/java/pm/bam/gamedeals/feature/store/ui/StoreScreenTest.kt
+++ b/feature/store/src/androidTest/java/pm/bam/gamedeals/feature/store/ui/StoreScreenTest.kt
@@ -22,11 +22,10 @@ import kotlinx.coroutines.flow.flowOf
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
+import pm.bam.gamedeals.common.ui.deal.DealBottomSheetData
 import pm.bam.gamedeals.common.ui.theme.GameDealsTheme
 import pm.bam.gamedeals.domain.models.Deal
 import pm.bam.gamedeals.domain.models.Store
-import pm.bam.gamedeals.feature.deal.ui.DealBottomSheetData
-import pm.bam.gamedeals.feature.deal.ui.DealDetailsViewModel
 
 class StoreScreenTest {
 
@@ -36,8 +35,6 @@ class StoreScreenTest {
     private val deal: Deal = mockk()
 
     private val viewModel: StoreViewModel = mockk()
-
-    private val dealDealDetailsViewModel: DealDetailsViewModel = mockk()
 
     private val storeId = 1
 
@@ -57,7 +54,7 @@ class StoreScreenTest {
         val storeDetails: StateFlow<Store?> = MutableStateFlow(null)
 
         every { viewModel.deals } returns dealPaging
-        every { dealDealDetailsViewModel.dealDealDetails } returns dealDetails
+        every { viewModel.dealDetails } returns dealDetails
         every { viewModel.storeDetails } returns storeDetails
     }
 
@@ -82,8 +79,7 @@ class StoreScreenTest {
                     storeId = storeId,
                     onBack = {},
                     goToWeb = { _, _ -> },
-                    viewModel = viewModel,
-                    dealDealDetailsViewModel = dealDealDetailsViewModel
+                    viewModel = viewModel
                 )
             }
         }
@@ -92,7 +88,7 @@ class StoreScreenTest {
             .assertIsDisplayed()
 
         verify(exactly = 1) { viewModel.deals }
-        verify(exactly = 1) { dealDealDetailsViewModel.dealDealDetails }
+        verify(exactly = 1) { viewModel.dealDetails }
         verify(exactly = 1) { viewModel.storeDetails }
         verify(exactly = 1) { viewModel.setStoreId(storeId) }
     }
@@ -107,14 +103,13 @@ class StoreScreenTest {
                     storeId = storeId,
                     onBack = {},
                     goToWeb = { _, _ -> },
-                    viewModel = viewModel,
-                    dealDealDetailsViewModel = dealDealDetailsViewModel
+                    viewModel = viewModel
                 )
             }
         }
 
         verify(exactly = 1) { viewModel.deals }
-        verify(exactly = 1) { dealDealDetailsViewModel.dealDealDetails }
+        verify(exactly = 1) { viewModel.dealDetails }
         verify(exactly = 1) { viewModel.storeDetails }
         verify(exactly = 1) { viewModel.setStoreId(storeId) }
     }
@@ -122,7 +117,7 @@ class StoreScreenTest {
     @Test
     fun loadDealDetails() {
         every { viewModel.setStoreId(any()) } just runs
-        every { dealDealDetailsViewModel.loadDealDetails(any(), any(), any(), any()) } just runs
+        every { viewModel.loadDealDetails(any(), any(), any(), any()) } just runs
 
         composeTestRule.setContent {
             GameDealsTheme {
@@ -130,8 +125,7 @@ class StoreScreenTest {
                     storeId = storeId,
                     onBack = {},
                     goToWeb = { _, _ -> },
-                    viewModel = viewModel,
-                    dealDealDetailsViewModel = dealDealDetailsViewModel
+                    viewModel = viewModel
                 )
             }
         }
@@ -140,10 +134,10 @@ class StoreScreenTest {
             .performClick()
 
         verify(exactly = 1) { viewModel.deals }
-        verify(exactly = 1) { dealDealDetailsViewModel.dealDealDetails }
+        verify(exactly = 1) { viewModel.dealDetails }
         verify(exactly = 1) { viewModel.storeDetails }
         verify(exactly = 1) { viewModel.setStoreId(storeId) }
-        verify(exactly = 1) { dealDealDetailsViewModel.loadDealDetails(any(), any(), any(), any()) }
+        verify(exactly = 1) { viewModel.loadDealDetails(any(), any(), any(), any()) }
     }
 
     @Test
@@ -168,8 +162,7 @@ class StoreScreenTest {
                     storeId = storeId,
                     onBack = {},
                     goToWeb = { _, _ -> },
-                    viewModel = viewModel,
-                    dealDealDetailsViewModel = dealDealDetailsViewModel
+                    viewModel = viewModel
                 )
             }
         }
@@ -181,7 +174,7 @@ class StoreScreenTest {
 
 
         verify(exactly = 1) { viewModel.deals }
-        verify(exactly = 1) { dealDealDetailsViewModel.dealDealDetails }
+        verify(exactly = 1) { viewModel.dealDetails }
         verify(exactly = 1) { viewModel.storeDetails }
         verify(exactly = 1) { viewModel.setStoreId(storeId) }
     }
@@ -199,8 +192,7 @@ class StoreScreenTest {
                     storeId = storeId,
                     onBack = onBack,
                     goToWeb = { _, _ -> },
-                    viewModel = viewModel,
-                    dealDealDetailsViewModel = dealDealDetailsViewModel
+                    viewModel = viewModel
                 )
             }
         }
@@ -209,7 +201,7 @@ class StoreScreenTest {
             .performClick()
 
         verify(exactly = 1) { viewModel.deals }
-        verify(exactly = 1) { dealDealDetailsViewModel.dealDealDetails }
+        verify(exactly = 1) { viewModel.dealDetails }
         verify(exactly = 1) { viewModel.storeDetails }
         verify(exactly = 1) { viewModel.setStoreId(storeId) }
         verify(exactly = 1) { onBack.invoke() }

--- a/feature/store/src/main/java/pm/bam/gamedeals/feature/store/ui/StoreScreen.kt
+++ b/feature/store/src/main/java/pm/bam/gamedeals/feature/store/ui/StoreScreen.kt
@@ -55,12 +55,11 @@ import pm.bam.gamedeals.common.ui.PreviewDeal
 import pm.bam.gamedeals.common.ui.PreviewStore
 import pm.bam.gamedeals.common.ui.TabletLandscape
 import pm.bam.gamedeals.common.ui.TabletPortrait
+import pm.bam.gamedeals.common.ui.deal.DealBottomSheet
+import pm.bam.gamedeals.common.ui.deal.DealBottomSheetData
 import pm.bam.gamedeals.common.ui.theme.GameDealsCustomTheme
 import pm.bam.gamedeals.domain.models.Deal
 import pm.bam.gamedeals.domain.models.Store
-import pm.bam.gamedeals.feature.deal.ui.DealBottomSheet
-import pm.bam.gamedeals.feature.deal.ui.DealBottomSheetData
-import pm.bam.gamedeals.feature.deal.ui.DealDetailsViewModel
 import pm.bam.gamedeals.feature.store.R
 
 @Composable
@@ -68,15 +67,14 @@ internal fun StoreScreen(
     storeId: Int,
     onBack: () -> Unit,
     goToWeb: (url: String, gameTitle: String) -> Unit,
-    viewModel: StoreViewModel = hiltViewModel(),
-    dealDealDetailsViewModel: DealDetailsViewModel = hiltViewModel()
+    viewModel: StoreViewModel = hiltViewModel()
 ) {
     viewModel.setStoreId(storeId)
 
     val deals: LazyPagingItems<Deal> = viewModel.deals.collectAsLazyPagingItems()
     val storeDetails = viewModel.storeDetails.collectAsStateWithLifecycle()
 
-    val dealDetails = dealDealDetailsViewModel.dealDealDetails.collectAsStateWithLifecycle()
+    val dealDetails = viewModel.dealDetails.collectAsStateWithLifecycle()
 
     StoreDeals(
         deals = deals,
@@ -84,14 +82,14 @@ internal fun StoreScreen(
         storeDetails = storeDetails.value,
         onBack = onBack,
         onLoadDealDetails = { dealId, dealStoreId, dealTitle, dealPriceDenominated ->
-            dealDealDetailsViewModel.loadDealDetails(
+            viewModel.loadDealDetails(
                 dealId = dealId,
                 dealStoreId = dealStoreId,
                 dealTitle = dealTitle,
                 dealPriceDenominated = dealPriceDenominated,
             )
         },
-        onDismissDealDetails = { dealDealDetailsViewModel.dismissDealDetails() },
+        onDismissDealDetails = { viewModel.dismissDealDetails() },
         goToWeb = goToWeb
     )
 }

--- a/feature/store/src/main/java/pm/bam/gamedeals/feature/store/ui/StoreViewModel.kt
+++ b/feature/store/src/main/java/pm/bam/gamedeals/feature/store/ui/StoreViewModel.kt
@@ -18,12 +18,11 @@ import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import pm.bam.gamedeals.common.logFlow
 import pm.bam.gamedeals.common.ui.deal.DealBottomSheetData
-import pm.bam.gamedeals.common.withMinimumDuration
+import pm.bam.gamedeals.common.ui.deal.DealDetailsController
 import pm.bam.gamedeals.domain.models.Store
 import pm.bam.gamedeals.domain.repositories.deals.DealsRepository
 import pm.bam.gamedeals.domain.repositories.stores.StoresRepository
 import pm.bam.gamedeals.logging.Logger
-import pm.bam.gamedeals.logging.fatal
 import javax.inject.Inject
 
 @HiltViewModel
@@ -43,12 +42,8 @@ internal class StoreViewModel @Inject constructor(
         initialValue = null
     )
 
-    private val _dealDetails = MutableStateFlow<DealBottomSheetData?>(null)
-    val dealDetails: StateFlow<DealBottomSheetData?> = _dealDetails.stateIn(
-        scope = viewModelScope,
-        started = SharingStarted.WhileSubscribed(5000),
-        initialValue = null
-    )
+    private val dealDetailsController = DealDetailsController(dealsRepository, storesRepository, logger)
+    val dealDetails: StateFlow<DealBottomSheetData?> = dealDetailsController.dealDetails
 
     init {
         viewModelScope.launch {
@@ -75,60 +70,11 @@ internal class StoreViewModel @Inject constructor(
         .catch { logger.fatalThrowable(it) }
         .logFlow(logger)
 
-    fun loadDealDetails(
-        dealId: String,
-        dealStoreId: Int,
-        dealTitle: String,
-        dealPriceDenominated: String
-    ) {
-        viewModelScope.launch {
-            try {
-                _dealDetails.emit(
-                    DealBottomSheetData.DealDetailsLoading(
-                        store = storesRepository.getStore(dealStoreId),
-                        gameName = dealTitle,
-                        dealId = dealId,
-                        gameSalesPriceDenominated = dealPriceDenominated
-                    )
-                )
-
-                val data = withMinimumDuration(750L) {
-                    val dealDetails = dealsRepository.getDeal(dealId)
-                    val store = storesRepository.getStore(dealStoreId)
-
-                    DealBottomSheetData.DealDetailsData(
-                        store = store,
-                        gameName = dealTitle,
-                        dealId = dealId,
-                        gameSalesPriceDenominated = dealPriceDenominated,
-                        gameInfo = dealDetails.gameInfo,
-                        cheapestPrice = dealDetails.cheapestPrice,
-                        cheaperStores = dealDetails.cheaperStores.map { storesRepository.getStore(it.storeID) to it }
-                    )
-                }
-                _dealDetails.emit(data)
-            } catch (t: Throwable) {
-                fatal(logger, t)
-                try {
-                    _dealDetails.emit(
-                        DealBottomSheetData.DealDetailsError(
-                            store = storesRepository.getStore(dealStoreId),
-                            gameName = dealTitle,
-                            dealId = dealId,
-                            gameSalesPriceDenominated = dealPriceDenominated
-                        )
-                    )
-                } catch (inner: Throwable) {
-                    fatal(logger, inner)
-                    dismissDealDetails()
-                }
-            }
-        }
+    fun loadDealDetails(dealId: String, dealStoreId: Int, dealTitle: String, dealPriceDenominated: String) {
+        dealDetailsController.load(viewModelScope, dealId, dealStoreId, dealTitle, dealPriceDenominated)
     }
 
     fun dismissDealDetails() {
-        viewModelScope.launch {
-            _dealDetails.emit(null)
-        }
+        dealDetailsController.dismiss(viewModelScope)
     }
 }

--- a/feature/store/src/main/java/pm/bam/gamedeals/feature/store/ui/StoreViewModel.kt
+++ b/feature/store/src/main/java/pm/bam/gamedeals/feature/store/ui/StoreViewModel.kt
@@ -17,10 +17,13 @@ import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import pm.bam.gamedeals.common.logFlow
+import pm.bam.gamedeals.common.ui.deal.DealBottomSheetData
+import pm.bam.gamedeals.common.withMinimumDuration
 import pm.bam.gamedeals.domain.models.Store
 import pm.bam.gamedeals.domain.repositories.deals.DealsRepository
 import pm.bam.gamedeals.domain.repositories.stores.StoresRepository
 import pm.bam.gamedeals.logging.Logger
+import pm.bam.gamedeals.logging.fatal
 import javax.inject.Inject
 
 @HiltViewModel
@@ -35,6 +38,13 @@ internal class StoreViewModel @Inject constructor(
 
     private val _storeDetails = MutableStateFlow<Store?>(null)
     val storeDetails: StateFlow<Store?> = _storeDetails.stateIn(
+        scope = viewModelScope,
+        started = SharingStarted.WhileSubscribed(5000),
+        initialValue = null
+    )
+
+    private val _dealDetails = MutableStateFlow<DealBottomSheetData?>(null)
+    val dealDetails: StateFlow<DealBottomSheetData?> = _dealDetails.stateIn(
         scope = viewModelScope,
         started = SharingStarted.WhileSubscribed(5000),
         initialValue = null
@@ -64,4 +74,61 @@ internal class StoreViewModel @Inject constructor(
         .cachedIn(viewModelScope)
         .catch { logger.fatalThrowable(it) }
         .logFlow(logger)
+
+    fun loadDealDetails(
+        dealId: String,
+        dealStoreId: Int,
+        dealTitle: String,
+        dealPriceDenominated: String
+    ) {
+        viewModelScope.launch {
+            try {
+                _dealDetails.emit(
+                    DealBottomSheetData.DealDetailsLoading(
+                        store = storesRepository.getStore(dealStoreId),
+                        gameName = dealTitle,
+                        dealId = dealId,
+                        gameSalesPriceDenominated = dealPriceDenominated
+                    )
+                )
+
+                val data = withMinimumDuration(750L) {
+                    val dealDetails = dealsRepository.getDeal(dealId)
+                    val store = storesRepository.getStore(dealStoreId)
+
+                    DealBottomSheetData.DealDetailsData(
+                        store = store,
+                        gameName = dealTitle,
+                        dealId = dealId,
+                        gameSalesPriceDenominated = dealPriceDenominated,
+                        gameInfo = dealDetails.gameInfo,
+                        cheapestPrice = dealDetails.cheapestPrice,
+                        cheaperStores = dealDetails.cheaperStores.map { storesRepository.getStore(it.storeID) to it }
+                    )
+                }
+                _dealDetails.emit(data)
+            } catch (t: Throwable) {
+                fatal(logger, t)
+                try {
+                    _dealDetails.emit(
+                        DealBottomSheetData.DealDetailsError(
+                            store = storesRepository.getStore(dealStoreId),
+                            gameName = dealTitle,
+                            dealId = dealId,
+                            gameSalesPriceDenominated = dealPriceDenominated
+                        )
+                    )
+                } catch (inner: Throwable) {
+                    fatal(logger, inner)
+                    dismissDealDetails()
+                }
+            }
+        }
+    }
+
+    fun dismissDealDetails() {
+        viewModelScope.launch {
+            _dealDetails.emit(null)
+        }
+    }
 }


### PR DESCRIPTION
Closes #20

> **Wave 2 stacked on PR #26.** This branch is based on `refactor/18-24-screen-state`. Once #26 merges to `dev`, this PR will be rebased onto `dev` and re-targeted there.

## Summary

Resolve `:feature:deal`'s dual role (Option 1 from the issue): the embeddable deal-detail surface now lives in `:common:ui`. `:feature:home` and `:feature:store` no longer transitively pull in `:feature:deal`'s Hilt graph, and a tweak to the shared deal-detail composable no longer ripples through two unrelated features.

## What moved (file-level)

- `feature/deal/src/main/java/pm/bam/gamedeals/feature/deal/ui/DealBottomSheet.kt` -> `common/ui/src/main/java/pm/bam/gamedeals/common/ui/deal/DealBottomSheet.kt`
  - Includes `DealBottomSheet` composable, `DealBottomSheetData` sealed class, `DEAL_URL`, all internal test tags, and previews.
  - Composable already takes plain `data: DealBottomSheetData?` + callbacks - no Hilt dependency.
- `feature/deal/src/main/res/values/strings.xml` -> `common/ui/src/main/res/values/strings.xml`
  - Only deal-detail strings (the file's full contents) move. `R.string` references in the moved composable now resolve against `pm.bam.gamedeals.common.ui.R`.
- `feature/deal/src/androidTest/java/pm/bam/gamedeals/feature/deal/ui/DealBottomSheetTest.kt` -> `common/ui/src/androidTest/java/pm/bam/gamedeals/common/ui/deal/DealBottomSheetTest.kt`

## What stayed

- `DealDetailsViewModel` remains in `:feature:deal` as the canonical "top-level destination wrapper" entry point. It imports `DealBottomSheetData` from `:common:ui`. Its existing unit test stays in `:feature:deal`.
- `:common:ui` is still Hilt-free. The deal Hilt graph does not leak into common UI.

## Home / Store rewiring

- `HomeScreen` and `StoreScreen` no longer take a `DealDetailsViewModel` parameter.
- `HomeViewModel` and `StoreViewModel` each gain their own `dealDetails: StateFlow<DealBottomSheetData?>` plus `loadDealDetails(...)` / `dismissDealDetails()`. The shared composable continues to receive plain state + callbacks.
- `feature/home/build.gradle.kts` and `feature/store/build.gradle.kts` drop `implementation(project(":feature:deal"))`. Both depend on `:common:ui` for the shared surface.
- `:common:ui` build.gradle.kts gains `coil` + compose runtime + standard androidTest deps (mockk-android, compose-junit4, runner) so the moved `DealBottomSheetTest` compiles in its new home.

## Verification

All commands run locally with JDK 21 (Android Studio's bundled JBR):

- [x] `./gradlew clean :app:assembleDebug` - BUILD SUCCESSFUL
- [x] `./gradlew :feature:home:testDebugUnitTest :feature:store:testDebugUnitTest :feature:deal:testDebugUnitTest :common:ui:testDebugUnitTest` - BUILD SUCCESSFUL (no test regressions)
- [x] `./gradlew :feature:home:compileDebugAndroidTestKotlin :feature:store:compileDebugAndroidTestKotlin :common:ui:compileDebugAndroidTestKotlin` - BUILD SUCCESSFUL

### Negative checks

- [x] `grep -n "feature:deal" feature/home/build.gradle.kts feature/store/build.gradle.kts` - no `implementation(project(...))` references remain.
- [x] `grep -rn "pm.bam.gamedeals.feature.deal" feature/home/src feature/store/src` - no matches.

## Test plan

- [ ] Reviewer runs `./gradlew :app:assembleDebug` to confirm clean build.
- [ ] Reviewer runs the unit tests for home/store/deal/common:ui.
- [ ] Reviewer (optionally) runs the instrumented `DealBottomSheetTest`, `HomeScreenTest`, `StoreScreenTest` on a connected device/emulator.
- [ ] Manual smoke: open Home -> tap a deal row -> verify the bottom sheet appears and "Go to Deal" deep-links the same as before.
- [ ] Manual smoke: open a Store screen -> tap a deal -> same bottom-sheet behavior as before.

Generated with [Claude Code](https://claude.com/claude-code)