### PR TITLE
refactor(#19): extract shared CachedResource with injectable Clock

### DIFF
--- a/app/src/main/java/pm/bam/gamedeals/di/AppModule.kt
+++ b/app/src/main/java/pm/bam/gamedeals/di/AppModule.kt
@@ -12,6 +12,7 @@ import dagger.hilt.InstallIn
 import dagger.hilt.android.qualifiers.ApplicationContext
 import dagger.hilt.components.SingletonComponent
 import kotlinx.coroutines.Dispatchers
+import pm.bam.gamedeals.common.time.Clock
 import pm.bam.gamedeals.logging.Logger
 import pm.bam.gamedeals.logging.toLogLevel
 import javax.inject.Singleton
@@ -23,6 +24,15 @@ class AppModule {
     @Provides
     @Singleton
     fun provideFirebase(): FirebaseAnalytics = Firebase.analytics
+
+    /**
+     * System-clock adapter for the [Clock] port declared in `:common`.
+     * Lives in the composition root so `:domain`/`:common` never depend on a concrete clock.
+     * This is the only place in production code that calls [System.currentTimeMillis].
+     */
+    @Provides
+    @Singleton
+    fun provideClock(): Clock = Clock { System.currentTimeMillis() }
 
     @Coil
     @Provides

--- a/common/src/main/java/pm/bam/gamedeals/common/time/Clock.kt
+++ b/common/src/main/java/pm/bam/gamedeals/common/time/Clock.kt
@@ -1,0 +1,15 @@
+package pm.bam.gamedeals.common.time
+
+/**
+ * A small time-source abstraction so production code never reads the wall clock directly.
+ *
+ * Production code that needs "now" injects a [Clock] and calls [nowMillis]; tests inject a
+ * fake whose value can be advanced deterministically. The single concrete production
+ * implementation lives at the composition root (`:app`) and delegates to
+ * [System.currentTimeMillis].
+ */
+fun interface Clock {
+
+    /** Returns the current epoch time in milliseconds, equivalent to [System.currentTimeMillis]. */
+    fun nowMillis(): Long
+}

--- a/domain/src/main/java/pm/bam/gamedeals/domain/models/Deal.kt
+++ b/domain/src/main/java/pm/bam/gamedeals/domain/models/Deal.kt
@@ -9,7 +9,6 @@ import kotlinx.serialization.EncodeDefault
 import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
-import pm.bam.gamedeals.domain.utils.millisInHour
 
 @OptIn(ExperimentalSerializationApi::class)
 @Immutable
@@ -62,13 +61,14 @@ data class Deal(
     val thumb: String,
 
     /**
-     * An expiration date has been artificially to determine when
-     * the Store should be considered as expired, set as now + (something time).
+     * Epoch-millisecond expiry stamp written when the entity is persisted by the repository.
      *
-     * @see millisInHour
+     * The repository stamps this via the injected `Clock` plus the resource's TTL when adding
+     * fetched entities to the DAO; defaults to `0L` (already-expired) so any unstamped entity
+     * is considered stale by the cache.
      */
     @SerialName("expires")
-    val expires: Long = System.currentTimeMillis().plus(millisInHour * 8)
+    val expires: Long = 0L
 )
 
 @Serializable

--- a/domain/src/main/java/pm/bam/gamedeals/domain/models/Store.kt
+++ b/domain/src/main/java/pm/bam/gamedeals/domain/models/Store.kt
@@ -6,7 +6,6 @@ import androidx.room.Entity
 import androidx.room.PrimaryKey
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
-import pm.bam.gamedeals.domain.utils.millisInHour
 
 @Immutable
 @Entity(tableName = "Store")
@@ -23,13 +22,14 @@ data class Store(
     val images: StoreImages,
 
     /**
-     * An expiration date has been artificially to determine when
-     * the Store should be considered as expired, set as now + (something time).
+     * Epoch-millisecond expiry stamp written when the entity is persisted by the repository.
      *
-     * @see millisInHour
+     * The repository stamps this via the injected `Clock` plus the resource's TTL when adding
+     * fetched entities to the DAO; defaults to `0L` (already-expired) so any unstamped entity
+     * is considered stale by the cache.
      */
     @SerialName("expires")
-    val expires: Long = System.currentTimeMillis().plus(millisInHour * 8)
+    val expires: Long = 0L
 ) {
     @Immutable
     @Serializable

--- a/domain/src/main/java/pm/bam/gamedeals/domain/repositories/cache/CachedResource.kt
+++ b/domain/src/main/java/pm/bam/gamedeals/domain/repositories/cache/CachedResource.kt
@@ -1,0 +1,52 @@
+package pm.bam.gamedeals.domain.repositories.cache
+
+import pm.bam.gamedeals.common.time.Clock
+
+/**
+ * A small, deeply-tested abstraction over the project's repeated
+ * "if cache is empty or any entry is expired, clear-and-fetch under a transaction" pattern.
+ *
+ * Each repository wires one [CachedResource] per logical resource (e.g. "store deals for storeId",
+ * "all stores"). The repository tells the cache how to read existing entries, when an entry counts
+ * as expired, and how to perform the refresh. The cache decides — based solely on the injected
+ * [Clock] and the values returned by [read] — whether [refresh] should run.
+ *
+ * The cache is intentionally Flow-agnostic and free of Room types. The repository is responsible
+ * for running [refresh] inside `DomainDatabase.withTransaction { ... }` (where applicable), so this
+ * class stays a pure-Kotlin unit-testable seam without an Android dependency.
+ *
+ * @param clock Time source used to compare an entry's expiry to "now". The single production
+ *   `System.currentTimeMillis()` call lives in the [Clock] adapter.
+ * @param read Returns the currently-cached entries. An empty result is treated as "needs refresh".
+ * @param expiresAtMillis Returns the epoch-millisecond expiry of a single entry. The cache is
+ *   considered stale when [Clock.nowMillis] is strictly greater than this value for any entry —
+ *   matching the original `expires < System.currentTimeMillis()` semantics.
+ * @param refresh The repository's "clear + fetch + insert" body. Invoked when the cache decides a
+ *   refresh is required (or when the caller passes `force = true`).
+ */
+class CachedResource<T>(
+    private val clock: Clock,
+    private val read: suspend () -> List<T>,
+    private val expiresAtMillis: (T) -> Long,
+    private val refresh: suspend () -> Unit,
+) {
+
+    /**
+     * Refreshes the underlying cache when needed.
+     *
+     * @param force When `true`, skips the freshness check and always invokes [refresh].
+     * @return `true` when [refresh] was invoked, `false` when the cache was considered fresh.
+     */
+    suspend fun refreshIfNeeded(force: Boolean = false): Boolean {
+        val needed = force || isStale()
+        if (needed) refresh()
+        return needed
+    }
+
+    private suspend fun isStale(): Boolean {
+        val cached = read()
+        if (cached.isEmpty()) return true
+        val now = clock.nowMillis()
+        return cached.any { expiresAtMillis(it) < now }
+    }
+}

--- a/domain/src/main/java/pm/bam/gamedeals/domain/repositories/deals/DealsRepository.kt
+++ b/domain/src/main/java/pm/bam/gamedeals/domain/repositories/deals/DealsRepository.kt
@@ -7,27 +7,31 @@ import androidx.paging.PagingData
 import androidx.room.withTransaction
 import kotlinx.coroutines.flow.Flow
 import kotlinx.serialization.ExperimentalSerializationApi
+import pm.bam.gamedeals.common.time.Clock
 import pm.bam.gamedeals.domain.db.DomainDatabase
 import pm.bam.gamedeals.domain.db.dao.DealsDao
 import pm.bam.gamedeals.domain.models.Deal
 import pm.bam.gamedeals.domain.models.DealDetails
 import pm.bam.gamedeals.domain.models.SearchParameters
+import pm.bam.gamedeals.domain.repositories.cache.CachedResource
 import pm.bam.gamedeals.domain.repositories.deals.paging.DealsMediator
 import pm.bam.gamedeals.domain.source.CheapsharkSource
+import pm.bam.gamedeals.domain.utils.millisInHour
 import pm.bam.gamedeals.logging.Logger
 import pm.bam.gamedeals.logging.debug
-import pm.bam.gamedeals.logging.verbose
 import javax.inject.Inject
 import javax.inject.Singleton
 
 internal const val DEAL_PAGE_COUNT = 60
+internal val DEALS_TTL_MILLIS = millisInHour * 8
 
 @Singleton
 class DealsRepository @Inject internal constructor(
     private val logger: Logger,
     private val dealsDao: DealsDao,
     private val domainDatabase: DomainDatabase,
-    private val cheapsharkSource: CheapsharkSource
+    private val cheapsharkSource: CheapsharkSource,
+    private val clock: Clock,
 ) {
 
     fun observeAllDeals(): Flow<List<Deal>> =
@@ -60,22 +64,23 @@ class DealsRepository @Inject internal constructor(
 
     @OptIn(ExperimentalSerializationApi::class)
     suspend fun refreshDeals(storeId: Int, force: Boolean = false) {
-        val refresh = force || refreshNeeded(storeId)
+        val refreshed = storeDealsCache(storeId).refreshIfNeeded(force)
+        debug(logger) { "Store($storeId) Deals refresh needed: $refreshed" }
+    }
 
-        debug(logger) { "Store Deals refresh needed: $refresh" }
-
-        if (refresh) {
+    @OptIn(ExperimentalSerializationApi::class)
+    private fun storeDealsCache(storeId: Int): CachedResource<Deal> = CachedResource(
+        clock = clock,
+        read = { dealsDao.getStoreDeals(storeId) },
+        expiresAtMillis = { it.expires },
+        refresh = {
+            val expiresAt = clock.nowMillis() + DEALS_TTL_MILLIS
             domainDatabase.withTransaction {
                 dealsDao.clearDealsForStore(storeId)
                 cheapsharkSource.fetchDealsForStore(SearchParameters(storeID = storeId, pageSize = DEAL_PAGE_COUNT))
+                    .map { it.copy(expires = expiresAt) }
                     .let { dealsDao.addDeals(*it.toTypedArray()) }
             }
         }
-    }
-
-
-    private suspend fun refreshNeeded(storeId: Int): Boolean =
-        dealsDao.getStoreDeals(storeId)
-            .let { deals -> deals.isEmpty() || deals.any { it.expires < System.currentTimeMillis() } }
-            .apply { verbose(logger) { "Store($storeId) Deals Expiration logic returned: $this" } }
+    )
 }

--- a/domain/src/main/java/pm/bam/gamedeals/domain/repositories/stores/StoresRepository.kt
+++ b/domain/src/main/java/pm/bam/gamedeals/domain/repositories/stores/StoresRepository.kt
@@ -2,21 +2,38 @@ package pm.bam.gamedeals.domain.repositories.stores
 
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.onStart
+import pm.bam.gamedeals.common.time.Clock
 import pm.bam.gamedeals.domain.db.dao.StoresDao
 import pm.bam.gamedeals.domain.models.Store
+import pm.bam.gamedeals.domain.repositories.cache.CachedResource
 import pm.bam.gamedeals.domain.source.CheapsharkSource
+import pm.bam.gamedeals.domain.utils.millisInHour
 import pm.bam.gamedeals.logging.Logger
 import pm.bam.gamedeals.logging.debug
-import pm.bam.gamedeals.logging.verbose
 import javax.inject.Inject
 import javax.inject.Singleton
+
+internal val STORES_TTL_MILLIS = millisInHour * 8
 
 @Singleton
 class StoresRepository @Inject internal constructor(
     private val logger: Logger,
     private val storesDao: StoresDao,
-    private val cheapsharkSource: CheapsharkSource
+    private val cheapsharkSource: CheapsharkSource,
+    private val clock: Clock,
 ) {
+
+    private val cache = CachedResource(
+        clock = clock,
+        read = { storesDao.getAllStores() },
+        expiresAtMillis = { it.expires },
+        refresh = {
+            val expiresAt = clock.nowMillis() + STORES_TTL_MILLIS
+            cheapsharkSource.fetchStores()
+                .map { it.copy(expires = expiresAt) }
+                .let { storesDao.addStores(*it.toTypedArray()) }
+        }
+    )
 
     fun observeStores(): Flow<List<Store>> =
         storesDao.observeAllStores()
@@ -26,18 +43,7 @@ class StoresRepository @Inject internal constructor(
         storesDao.getStore(storeId)
 
     suspend fun refreshStores(force: Boolean = false) {
-        val refresh = force || refreshNeeded()
-
-        debug(logger) { "Stores refresh needed: $refresh" }
-
-        if (refresh) {
-            cheapsharkSource.fetchStores()
-                .let { storesDao.addStores(*it.toTypedArray()) }
-        }
+        val refreshed = cache.refreshIfNeeded(force)
+        debug(logger) { "Stores refresh needed: $refreshed" }
     }
-
-    private suspend fun refreshNeeded(): Boolean =
-        storesDao.getAllStores()
-            .let { stores -> stores.isEmpty() || stores.any { it.expires < System.currentTimeMillis() } }
-            .apply { verbose(logger) { "Stores Expiration logic returned: $this" } }
 }

--- a/domain/src/main/java/pm/bam/gamedeals/domain/utils/Constants.kt
+++ b/domain/src/main/java/pm/bam/gamedeals/domain/utils/Constants.kt
@@ -1,4 +1,4 @@
 package pm.bam.gamedeals.domain.utils
 
 internal const val IMAGE_BASE = "https://www.cheapshark.com"
-internal const val millisInHour = 60 * 60 * 1000
+const val millisInHour: Long = 60L * 60L * 1000L

--- a/domain/src/test/java/pm/bam/gamedeals/domain/repositories/cache/CachedResourceTest.kt
+++ b/domain/src/test/java/pm/bam/gamedeals/domain/repositories/cache/CachedResourceTest.kt
@@ -1,0 +1,164 @@
+package pm.bam.gamedeals.domain.repositories.cache
+
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import pm.bam.gamedeals.common.time.Clock
+
+/**
+ * Boundary test for [CachedResource]: a fake [Clock] proves that an expired entry triggers
+ * refresh and a fresh entry does not, without touching Room or any Android API.
+ *
+ * Picks a JVM unit test (over `androidTest` + in-memory Room) on purpose: [CachedResource] is
+ * Flow-/Room-free, so a JVM test is faster, deterministic, and matches the project's policy of
+ * not introducing Robolectric to drive deterministic-time tests (see L-2026-05-01-02).
+ */
+class CachedResourceTest {
+
+    private data class Entry(val id: Int, val expires: Long)
+
+    private class MutableClock(initial: Long) : Clock {
+        var nowMillis: Long = initial
+        override fun nowMillis(): Long = nowMillis
+    }
+
+    @Test
+    fun `empty cache - refreshIfNeeded - invokes refresh once and returns true`() = runTest {
+        val clock = MutableClock(initial = 1_000)
+        var refreshCount = 0
+        val cache = CachedResource(
+            clock = clock,
+            read = { emptyList<Entry>() },
+            expiresAtMillis = { it.expires },
+            refresh = { refreshCount++ },
+        )
+
+        val refreshed = cache.refreshIfNeeded()
+
+        assertTrue(refreshed)
+        assertEquals(1, refreshCount)
+    }
+
+    @Test
+    fun `fresh cache - refreshIfNeeded - skips refresh and returns false`() = runTest {
+        val clock = MutableClock(initial = 1_000)
+        var refreshCount = 0
+        val cache = CachedResource(
+            clock = clock,
+            read = { listOf(Entry(id = 1, expires = clock.nowMillis + 10_000)) },
+            expiresAtMillis = { it.expires },
+            refresh = { refreshCount++ },
+        )
+
+        val refreshed = cache.refreshIfNeeded()
+
+        assertFalse(refreshed)
+        assertEquals(0, refreshCount)
+    }
+
+    @Test
+    fun `expired entry - refreshIfNeeded - invokes refresh and returns true`() = runTest {
+        val clock = MutableClock(initial = 1_000)
+        var refreshCount = 0
+        val cache = CachedResource(
+            clock = clock,
+            // entry was valid until 999ms ago
+            read = { listOf(Entry(id = 1, expires = clock.nowMillis - 1)) },
+            expiresAtMillis = { it.expires },
+            refresh = { refreshCount++ },
+        )
+
+        val refreshed = cache.refreshIfNeeded()
+
+        assertTrue(refreshed)
+        assertEquals(1, refreshCount)
+    }
+
+    @Test
+    fun `mixed entries - any expired triggers refresh`() = runTest {
+        val clock = MutableClock(initial = 1_000)
+        var refreshCount = 0
+        val cache = CachedResource(
+            clock = clock,
+            read = {
+                listOf(
+                    Entry(id = 1, expires = clock.nowMillis + 10_000), // fresh
+                    Entry(id = 2, expires = clock.nowMillis - 1),      // expired
+                )
+            },
+            expiresAtMillis = { it.expires },
+            refresh = { refreshCount++ },
+        )
+
+        val refreshed = cache.refreshIfNeeded()
+
+        assertTrue(refreshed)
+        assertEquals(1, refreshCount)
+    }
+
+    @Test
+    fun `boundary - entry whose expires equals now is still fresh`() = runTest {
+        // Matches original `expires < currentTimeMillis()` semantics — equality is not yet expired.
+        val clock = MutableClock(initial = 1_000)
+        var refreshCount = 0
+        val cache = CachedResource(
+            clock = clock,
+            read = { listOf(Entry(id = 1, expires = clock.nowMillis)) },
+            expiresAtMillis = { it.expires },
+            refresh = { refreshCount++ },
+        )
+
+        val refreshed = cache.refreshIfNeeded()
+
+        assertFalse(refreshed)
+        assertEquals(0, refreshCount)
+    }
+
+    @Test
+    fun `same cache - clock advances past expiry - second call refreshes`() = runTest {
+        val clock = MutableClock(initial = 1_000)
+        val expiresAt = 5_000L
+        var refreshCount = 0
+        val cache = CachedResource(
+            clock = clock,
+            read = { listOf(Entry(id = 1, expires = expiresAt)) },
+            expiresAtMillis = { it.expires },
+            refresh = { refreshCount++ },
+        )
+
+        // before expiry
+        val first = cache.refreshIfNeeded()
+        // advance the fake clock past the entry's expiry
+        clock.nowMillis = expiresAt + 1
+        val second = cache.refreshIfNeeded()
+
+        assertFalse(first)
+        assertTrue(second)
+        assertEquals(1, refreshCount)
+    }
+
+    @Test
+    fun `force - true - bypasses freshness check and always refreshes`() = runTest {
+        val clock = MutableClock(initial = 1_000)
+        var refreshCount = 0
+        var readCount = 0
+        val cache = CachedResource(
+            clock = clock,
+            read = {
+                readCount++
+                listOf(Entry(id = 1, expires = clock.nowMillis + 10_000))
+            },
+            expiresAtMillis = { it.expires },
+            refresh = { refreshCount++ },
+        )
+
+        val refreshed = cache.refreshIfNeeded(force = true)
+
+        assertTrue(refreshed)
+        assertEquals(1, refreshCount)
+        // force avoids the read-and-compare path entirely
+        assertEquals(0, readCount)
+    }
+}

--- a/domain/src/test/java/pm/bam/gamedeals/domain/repositories/deals/DealsRepositoryTest.kt
+++ b/domain/src/test/java/pm/bam/gamedeals/domain/repositories/deals/DealsRepositoryTest.kt
@@ -10,6 +10,7 @@ import io.mockk.mockk
 import io.mockk.mockkStatic
 import io.mockk.runs
 import io.mockk.slot
+import io.mockk.verify
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.runTest
@@ -17,11 +18,13 @@ import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Rule
 import org.junit.Test
+import pm.bam.gamedeals.common.time.Clock
 import pm.bam.gamedeals.domain.db.DomainDatabase
 import pm.bam.gamedeals.domain.db.dao.DealsDao
 import pm.bam.gamedeals.domain.models.Deal
 import pm.bam.gamedeals.domain.models.DealDetails
 import pm.bam.gamedeals.domain.source.CheapsharkSource
+import pm.bam.gamedeals.domain.utils.millisInHour
 import pm.bam.gamedeals.logging.Logger
 import pm.bam.gamedeals.testing.TestingLoggingListener
 
@@ -39,7 +42,10 @@ class DealsRepositoryTest {
 
     private val cheapsharkSource: CheapsharkSource = mockk()
 
-    private val impl = DealsRepository(logger, dealsDao, domainDatabase, cheapsharkSource)
+    private val now = 1_000_000L
+    private val clock = Clock { now }
+
+    private val impl = DealsRepository(logger, dealsDao, domainDatabase, cheapsharkSource, clock)
 
 
     @Test
@@ -69,16 +75,18 @@ class DealsRepositoryTest {
 
 
     @Test
-    fun `refreshDeals - forced - fetches via source and writes to DAO`() = runTest {
+    fun `refreshDeals - forced - fetches via source, stamps expires, writes to DAO`() = runTest {
         val storeId = 1
-        val deal: Deal = mockk()
+        val fetched: Deal = mockk()
+        val stamped: Deal = mockk()
+        every { fetched.copy(expires = now + millisInHour * 8) } returns stamped
 
         mockkStatic("androidx.room.RoomDatabaseKt")
         val transactionLambda = slot<suspend () -> Unit>()
         coEvery { domainDatabase.withTransaction(capture(transactionLambda)) } coAnswers { transactionLambda.captured.invoke() }
 
         coEvery { dealsDao.clearDealsForStore(storeId) } just runs
-        coEvery { cheapsharkSource.fetchDealsForStore(query = any()) } returns listOf(deal)
+        coEvery { cheapsharkSource.fetchDealsForStore(query = any()) } returns listOf(fetched)
         coEvery { dealsDao.addDeals(*anyVararg()) } just runs
 
 
@@ -87,26 +95,27 @@ class DealsRepositoryTest {
 
         coVerify(exactly = 1) { dealsDao.clearDealsForStore(storeId) }
         coVerify(exactly = 1) { cheapsharkSource.fetchDealsForStore(query = any()) }
-        coVerify(exactly = 1) { dealsDao.addDeals(deal) }
+        coVerify(exactly = 1) { dealsDao.addDeals(stamped) }
+        verify(exactly = 1) { fetched.copy(expires = now + millisInHour * 8) }
     }
 
 
     @Test
     fun `refreshDeals - unforced - expired deals - fetches via source`() = runTest {
         val storeId = 1
-        val expiredDeal = mockk<Deal> {
-            every { expires } returns System.currentTimeMillis() - 10_000
-        }
-        val freshDeal: Deal = mockk()
+        val expired: Deal = mockk { every { expires } returns now - 10_000 }
+        val fetched: Deal = mockk()
+        val stamped: Deal = mockk()
+        every { fetched.copy(expires = now + millisInHour * 8) } returns stamped
 
-        coEvery { dealsDao.getStoreDeals(storeId) } returns listOf(expiredDeal)
+        coEvery { dealsDao.getStoreDeals(storeId) } returns listOf(expired)
 
         mockkStatic("androidx.room.RoomDatabaseKt")
         val transactionLambda = slot<suspend () -> Unit>()
         coEvery { domainDatabase.withTransaction(capture(transactionLambda)) } coAnswers { transactionLambda.captured.invoke() }
 
         coEvery { dealsDao.clearDealsForStore(storeId) } just runs
-        coEvery { cheapsharkSource.fetchDealsForStore(query = any()) } returns listOf(freshDeal)
+        coEvery { cheapsharkSource.fetchDealsForStore(query = any()) } returns listOf(fetched)
         coEvery { dealsDao.addDeals(*anyVararg()) } just runs
 
 
@@ -115,17 +124,15 @@ class DealsRepositoryTest {
 
         coVerify(exactly = 1) { dealsDao.clearDealsForStore(storeId) }
         coVerify(exactly = 1) { cheapsharkSource.fetchDealsForStore(query = any()) }
-        coVerify(exactly = 1) { dealsDao.addDeals(freshDeal) }
+        coVerify(exactly = 1) { dealsDao.addDeals(stamped) }
     }
 
 
     @Test
     fun `refreshDeals - unforced - skips source when DAO has fresh deals`() = runTest {
         val storeId = 1
-        val freshDeal = mockk<Deal> {
-            every { expires } returns System.currentTimeMillis() + 10_000
-        }
-        coEvery { dealsDao.getStoreDeals(storeId) } returns listOf(freshDeal)
+        val fresh: Deal = mockk { every { expires } returns now + 10_000 }
+        coEvery { dealsDao.getStoreDeals(storeId) } returns listOf(fresh)
 
 
         impl.refreshDeals(storeId)

--- a/domain/src/test/java/pm/bam/gamedeals/domain/repositories/stores/StoresRepositoryTest.kt
+++ b/domain/src/test/java/pm/bam/gamedeals/domain/repositories/stores/StoresRepositoryTest.kt
@@ -7,15 +7,18 @@ import io.mockk.every
 import io.mockk.just
 import io.mockk.mockk
 import io.mockk.runs
+import io.mockk.verify
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert
 import org.junit.Rule
 import org.junit.Test
+import pm.bam.gamedeals.common.time.Clock
 import pm.bam.gamedeals.domain.db.dao.StoresDao
 import pm.bam.gamedeals.domain.models.Store
 import pm.bam.gamedeals.domain.source.CheapsharkSource
+import pm.bam.gamedeals.domain.utils.millisInHour
 import pm.bam.gamedeals.logging.Logger
 import pm.bam.gamedeals.testing.TestingLoggingListener
 
@@ -30,16 +33,18 @@ class StoresRepositoryTest {
 
     private val cheapsharkSource: CheapsharkSource = mockk()
 
-    private val impl = StoresRepository(logger, storesDao, cheapsharkSource)
+    private val now = 1_000_000L
+    private val clock = Clock { now }
+
+    private val impl = StoresRepository(logger, storesDao, cheapsharkSource, clock)
+
 
     @Test
-    fun `observe stores with refresh called`() = runTest {
-        val results: Store = mockk {
-            every { expires } returns System.currentTimeMillis() + 10000
-        }
+    fun `observe stores - fresh cache - does not refresh`() = runTest {
+        val fresh: Store = mockk { every { expires } returns now + 10_000 }
 
-        coEvery { storesDao.observeAllStores() } returns flowOf(listOf())
-        coEvery { storesDao.getAllStores() } returns listOf(results)
+        coEvery { storesDao.observeAllStores() } returns flowOf(emptyList())
+        coEvery { storesDao.getAllStores() } returns listOf(fresh)
 
 
         val result = impl.observeStores().first()
@@ -48,59 +53,63 @@ class StoresRepositoryTest {
         coVerify(exactly = 0) { cheapsharkSource.fetchStores() }
         coVerify(exactly = 1) { storesDao.observeAllStores() }
         coVerify(exactly = 1) { storesDao.getAllStores() }
-        coVerify(exactly = 0) { storesDao.addStores(results) }
+        coVerify(exactly = 0) { storesDao.addStores(*anyVararg()) }
     }
 
 
     @Test
-    fun `refresh stores - unforced - expired deals`() = runTest {
-        val results: Store = mockk {
-            every { expires } returns 0
-        }
+    fun `refresh stores - unforced - expired entry - fetches and stamps expires`() = runTest {
+        val expired: Store = mockk { every { expires } returns now - 1 }
+        val fetched: Store = mockk()
+        val stamped: Store = mockk()
+        every { fetched.copy(expires = now + millisInHour * 8) } returns stamped
 
-        coEvery { cheapsharkSource.fetchStores() } returns listOf(results)
-        coEvery { storesDao.getAllStores() } returns listOf(results)
-        coEvery { storesDao.addStores(results) } just runs
+        coEvery { cheapsharkSource.fetchStores() } returns listOf(fetched)
+        coEvery { storesDao.getAllStores() } returns listOf(expired)
+        coEvery { storesDao.addStores(*anyVararg()) } just runs
 
 
         impl.refreshStores()
+
 
         coVerify(exactly = 1) { cheapsharkSource.fetchStores() }
         coVerify(exactly = 1) { storesDao.getAllStores() }
-        coVerify(exactly = 1) { storesDao.addStores(results) }
+        coVerify(exactly = 1) { storesDao.addStores(stamped) }
+        verify(exactly = 1) { fetched.copy(expires = now + millisInHour * 8) }
     }
 
-    @Test
-    fun `refresh deals - unforced - not expired deals`() = runTest {
-        val results: Store = mockk {
-            every { expires } returns System.currentTimeMillis() + 10000
-        }
 
-        coEvery { storesDao.getAllStores() } returns listOf(results)
+    @Test
+    fun `refresh stores - unforced - all fresh - skips fetch`() = runTest {
+        val fresh: Store = mockk { every { expires } returns now + 10_000 }
+
+        coEvery { storesDao.getAllStores() } returns listOf(fresh)
 
 
         impl.refreshStores()
+
 
         coVerify(exactly = 0) { cheapsharkSource.fetchStores() }
         coVerify(exactly = 1) { storesDao.getAllStores() }
-        coVerify(exactly = 0) { storesDao.addStores(results) }
+        coVerify(exactly = 0) { storesDao.addStores(*anyVararg()) }
     }
 
+
     @Test
-    fun `refresh deals - forced`() = runTest {
-        val results: Store = mockk {
-            every { expires } returns 0
-        }
+    fun `refresh stores - forced - skips freshness check and stamps expires`() = runTest {
+        val fetched: Store = mockk()
+        val stamped: Store = mockk()
+        every { fetched.copy(expires = now + millisInHour * 8) } returns stamped
 
-        coEvery { cheapsharkSource.fetchStores() } returns listOf(results)
-        coEvery { storesDao.getAllStores() } returns listOf(results)
-        coEvery { storesDao.addStores(results) } just runs
+        coEvery { cheapsharkSource.fetchStores() } returns listOf(fetched)
+        coEvery { storesDao.addStores(*anyVararg()) } just runs
 
 
-        impl.refreshStores()
+        impl.refreshStores(force = true)
+
 
         coVerify(exactly = 1) { cheapsharkSource.fetchStores() }
-        coVerify(exactly = 1) { storesDao.getAllStores() }
-        coVerify(exactly = 1) { storesDao.addStores(results) }
+        coVerify(exactly = 0) { storesDao.getAllStores() }
+        coVerify(exactly = 1) { storesDao.addStores(stamped) }
     }
 }


### PR DESCRIPTION
## Summary

Closes #19.

Extracts a small, deeply-tested `CachedResource<T>` abstraction in `:domain` and an injectable `Clock` port in `:common`, replacing the per-repository `private suspend fun refreshNeeded()` duplication that called `System.currentTimeMillis()` directly. Now any repository's freshness decision is one `cache.refreshIfNeeded(force)` call against an injected `Clock`, and tests can advance time deterministically.

## What changed per module

- **`:common`** - new `pm.bam.gamedeals.common.time.Clock` `fun interface` (`nowMillis(): Long`). No new dependencies.
- **`:app`** - new `@Provides @Singleton fun provideClock(): Clock = Clock { System.currentTimeMillis() }` in `AppModule`. This is the only `System.currentTimeMillis()` call in the production cache/data flow.
- **`:domain`**:
  - new `pm.bam.gamedeals.domain.repositories.cache.CachedResource<T>` - takes `Clock`, `read`, `expiresAtMillis`, `refresh`. Pure-Kotlin, Flow-/Room-free.
  - `DealsRepository` and `StoresRepository` each instantiate one `CachedResource` per logical resource. Their `refresh` body still runs inside `domainDatabase.withTransaction { ... }` where applicable. `private fun refreshNeeded(...)` is gone from both.
  - On insert, both repositories `.copy(expires = clock.nowMillis() + TTL_MILLIS)` the fetched entities, so freshness-stamping happens at the boundary, not in a model default.
  - `Deal.expires` and `Store.expires` defaults drop from `System.currentTimeMillis().plus(...)` to `0L` (already-expired). PreviewData consumers continue to compile because the parameter is omitted.
  - `millisInHour` promoted from `internal const Int` to public `const Long` so repositories can compute TTLs from it.
- **`:domain` tests**:
  - `DealsRepositoryTest` and `StoresRepositoryTest` now construct the repo with a fake `Clock { 1_000_000L }` and assert the expires-stamping. No reliance on `System.currentTimeMillis()`.
  - new `CachedResourceTest` is the deep boundary test (7 cases): empty / fresh / expired / mixed / equality-boundary / clock-advance / force.

## How `Clock` is wired

```
:common  → defines  fun interface Clock
:domain  → consumes Clock (constructor-injected into repos and CachedResource)
:app     → @Provides Clock { System.currentTimeMillis() }   // single adapter
```

This follows L-2026-04-30-01: ports in `:common`/`:domain`, adapter at the composition root.

Repository constructors stay `public class XxxRepository @Inject internal constructor(...)` per L-2026-04-30-03 - the class is public so feature modules can inject by type, the constructor stays `internal` because it takes `internal`-typed Daos. Adding `Clock` did not require touching the visibility modifiers.

## Test plan

- [x] `./gradlew :domain:testDebugUnitTest` - all green (existing repo tests + new `CachedResourceTest` + updated repo tests)
- [x] `./gradlew testDebugUnitTest` - all module unit tests green
- [x] `./gradlew assembleDebug` - debug APK builds end-to-end
- [x] `grep -r "System.currentTimeMillis" --include='*.kt'` in production source confirms one call in the cache/data flow (`AppModule.provideClock`). The remaining production calls live in `:common/FlowExtensions.kt`'s `withMinimumDuration` / `mapDelayAtLeast` / `latestDelayAtLeast` / `flatMapLatestDelayAtLeast` - those measure UX wall-clock duration, not cache expiry, and are out of scope for this issue.
- [x] `grep -r "refreshNeeded" --include='*.kt'` confirms zero matches in production source.
- [ ] CI green on this PR.

## Notes

- Boundary test for `CachedResource` runs as a **JVM unit test**, not `androidTest` - the abstraction is intentionally Room-free, so a fake `Clock` is enough; no Robolectric (per L-2026-05-01-02).
- `StoresRepository` had its own self-bootstrapping `observeStores().onStart { refreshStores() }`. That behaviour is preserved exactly - the `onStart` now consults the `CachedResource` instead of the inline helper.
- `:remote:*` mappers don't pass `expires`, so removing the `currentTimeMillis()` default to `0L` is a no-op for the remote read path - the repo immediately stamps the correct expiry before persisting.
- Out of scope per the issue's Constraints section: ViewModels are untouched (no `viewModelScope.launch try/catch` lowering, no `flow { emitAll(...) }` unwrapping, no `_uiState.stateIn` rework, no `runCatching`-in-Flow migration).
- The `System.currentTimeMillis()` calls in `FlowExtensions.kt` (loading-duration UX timing) are unrelated to expiring-cache logic. If desired, a follow-up issue could route those through `Clock` too, but it would change semantics from "elapsed wall-clock" to "elapsed clock-time" and was not requested by this issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)