### PR TITLE
refactor(#22): introduce build-logic convention plugins

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -2,10 +2,7 @@ import java.io.FileInputStream
 import java.util.Properties
 
 plugins {
-    alias(libs.plugins.android.application)
-    alias(libs.plugins.jetbrains.kotlin)
-    alias(libs.plugins.kotlin.ksp)
-    alias(libs.plugins.compose)
+    alias(libs.plugins.gamedeals.android.application)
     alias(libs.plugins.hilt)
     alias(libs.plugins.google.services)
     alias(libs.plugins.firebase.crashlytics)
@@ -13,8 +10,6 @@ plugins {
 
 android {
     namespace = "pm.bam.gamedeals"
-    compileSdk = 36
-
 
     // START - RELEASE SIGNING CONFIGURATION
     // Create variables to store the release key information
@@ -63,7 +58,6 @@ android {
 
     defaultConfig {
         applicationId = "pm.bam.gamedeals"
-        minSdk = 26
         targetSdk = 34
         versionCode = 9
         versionName = "1.0.6"
@@ -81,33 +75,6 @@ android {
 
             signingConfig = signingConfigs.getByName(releaseSigningKey)
         }
-    }
-    compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_21
-        targetCompatibility = JavaVersion.VERSION_21
-    }
-    kotlin {
-        jvmToolchain(21)
-    }
-    buildFeatures {
-        compose = true
-    }
-    composeOptions {
-        kotlinCompilerExtensionVersion = "1.5.11"
-    }
-    packaging {
-        resources {
-
-            excludes += "/META-INF/LICENSE.md"
-            excludes += "/META-INF/LICENSE-notice.md"
-            excludes += "/META-INF/{AL2.0,LGPL2.1}"
-
-            // Temporary fix for OSGi issue org.jspecify:jspecify:1.0.0 and com.squareup.okhttp3:logging-interceptor:5.2.1
-            excludes += "META-INF/versions/9/OSGI-INF/MANIFEST.MF"
-        }
-    }
-    tasks.withType<Test> {
-        jvmArgs = listOf("-XX:+EnableDynamicAgentLoading")
     }
 }
 

--- a/base/build.gradle.kts
+++ b/base/build.gradle.kts
@@ -1,51 +1,18 @@
 plugins {
-    alias(libs.plugins.androidLibrary)
-    alias(libs.plugins.jetbrains.kotlin)
-    alias(libs.plugins.kotlin.ksp)
+    alias(libs.plugins.gamedeals.android.library)
+    alias(libs.plugins.gamedeals.android.ksp)
     alias(libs.plugins.hilt)
 }
 
 android {
     namespace = "pm.bam.gamedeals.base"
-    compileSdk = 36
 
     defaultConfig {
-        minSdk = 26
-
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
-    }
-
-    buildTypes {
-        release {
-            isMinifyEnabled = false
-            proguardFiles(getDefaultProguardFile("proguard-android-optimize.txt"))
-        }
-    }
-    compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_21
-        targetCompatibility = JavaVersion.VERSION_21
-    }
-    kotlin {
-        jvmToolchain(21)
-    }
-    packaging {
-        resources {
-
-            excludes += "/META-INF/LICENSE.md"
-            excludes += "/META-INF/LICENSE-notice.md"
-            excludes += "/META-INF/{AL2.0,LGPL2.1}"
-
-            // Temporary fix for OSGi issue org.jspecify:jspecify:1.0.0 and com.squareup.okhttp3:logging-interceptor:5.2.1
-            excludes += "META-INF/versions/9/OSGI-INF/MANIFEST.MF"
-        }
-    }
-    tasks.withType<Test> {
-        jvmArgs = listOf("-XX:+EnableDynamicAgentLoading")
     }
 }
 
 dependencies {
-
     implementation(project(":common"))
     implementation(project(":logging"))
 

--- a/build-logic/build.gradle.kts
+++ b/build-logic/build.gradle.kts
@@ -1,0 +1,1 @@
+// Empty root build file for the included build. Module config lives under :convention.

--- a/build-logic/convention/build.gradle.kts
+++ b/build-logic/convention/build.gradle.kts
@@ -1,0 +1,49 @@
+plugins {
+    `kotlin-dsl`
+}
+
+group = "pm.bam.gamedeals.buildlogic"
+
+// Match the JDK target used by the rest of the project so the precompiled
+// plugin classes link against JDK 21 bytecode and avoid JavaCompile mismatches
+// on CI (see lesson L-2026-04-30-02).
+java {
+    sourceCompatibility = JavaVersion.VERSION_21
+    targetCompatibility = JavaVersion.VERSION_21
+}
+
+kotlin {
+    jvmToolchain(21)
+}
+
+dependencies {
+    compileOnly(libs.android.gradle.plugin)
+    compileOnly(libs.kotlin.gradle.plugin)
+    compileOnly(libs.ksp.gradle.plugin)
+    compileOnly(libs.compose.gradle.plugin)
+}
+
+gradlePlugin {
+    plugins {
+        register("androidLibrary") {
+            id = "pm.bam.gamedeals.android.library"
+            implementationClass = "pm.bam.gamedeals.AndroidLibraryConventionPlugin"
+        }
+        register("androidLibraryCompose") {
+            id = "pm.bam.gamedeals.android.library.compose"
+            implementationClass = "pm.bam.gamedeals.AndroidLibraryComposeConventionPlugin"
+        }
+        register("androidKsp") {
+            id = "pm.bam.gamedeals.android.ksp"
+            implementationClass = "pm.bam.gamedeals.AndroidKspConventionPlugin"
+        }
+        register("androidFeature") {
+            id = "pm.bam.gamedeals.android.feature"
+            implementationClass = "pm.bam.gamedeals.AndroidFeatureConventionPlugin"
+        }
+        register("androidApplication") {
+            id = "pm.bam.gamedeals.android.application"
+            implementationClass = "pm.bam.gamedeals.AndroidApplicationConventionPlugin"
+        }
+    }
+}

--- a/build-logic/convention/build.gradle.kts
+++ b/build-logic/convention/build.gradle.kts
@@ -4,9 +4,6 @@ plugins {
 
 group = "pm.bam.gamedeals.buildlogic"
 
-// Match the JDK target used by the rest of the project so the precompiled
-// plugin classes link against JDK 21 bytecode and avoid JavaCompile mismatches
-// on CI (see lesson L-2026-04-30-02).
 java {
     sourceCompatibility = JavaVersion.VERSION_21
     targetCompatibility = JavaVersion.VERSION_21

--- a/build-logic/convention/src/main/kotlin/pm/bam/gamedeals/AndroidApplicationConventionPlugin.kt
+++ b/build-logic/convention/src/main/kotlin/pm/bam/gamedeals/AndroidApplicationConventionPlugin.kt
@@ -1,0 +1,29 @@
+package pm.bam.gamedeals
+
+import com.android.build.api.dsl.ApplicationExtension
+import org.gradle.api.Plugin
+import org.gradle.api.Project
+import org.gradle.kotlin.dsl.configure
+
+/**
+ * Convention plugin for the single `:app` Android application module.
+ *
+ * Mirrors [AndroidLibraryConventionPlugin] but for `com.android.application`,
+ * and additionally applies the Compose compiler plugin and KSP because the app
+ * always needs both. Hilt / Firebase / signing-config / version metadata stay
+ * in `:app/build.gradle.kts` because they are inherently single-module
+ * concerns.
+ */
+class AndroidApplicationConventionPlugin : Plugin<Project> {
+    override fun apply(target: Project) = with(target) {
+        pluginManager.apply("com.android.application")
+        pluginManager.apply("org.jetbrains.kotlin.android")
+        pluginManager.apply("org.jetbrains.kotlin.plugin.compose")
+        pluginManager.apply("com.google.devtools.ksp")
+
+        extensions.configure<ApplicationExtension> {
+            configureAndroidCommon(this)
+            buildFeatures.compose = true
+        }
+    }
+}

--- a/build-logic/convention/src/main/kotlin/pm/bam/gamedeals/AndroidCommon.kt
+++ b/build-logic/convention/src/main/kotlin/pm/bam/gamedeals/AndroidCommon.kt
@@ -1,0 +1,57 @@
+package pm.bam.gamedeals
+
+import com.android.build.api.dsl.CommonExtension
+import org.gradle.api.JavaVersion
+import org.gradle.api.Project
+import org.gradle.api.tasks.testing.Test
+import org.gradle.kotlin.dsl.withType
+import org.jetbrains.kotlin.gradle.dsl.KotlinAndroidProjectExtension
+
+/**
+ * Shared Android compile / packaging defaults for both library and application modules.
+ *
+ * Centralises the previously-duplicated `compileSdk`, `minSdk`, JDK 21 source/target
+ * compatibility, the OSGi packaging-resource excludes (org.jspecify / okhttp logging
+ * interceptor), and the `-XX:+EnableDynamicAgentLoading` JVM arg required by Mockk's
+ * inline mock-maker on JDK 21+.
+ *
+ * Per project policy this stays purely structural: do not bump SDK levels here without
+ * also coordinating an explicit version-bump PR.
+ */
+internal fun Project.configureAndroidCommon(extension: CommonExtension<*, *, *, *, *, *>) {
+    extension.apply {
+        compileSdk = 36
+
+        defaultConfig {
+            minSdk = 26
+        }
+
+        compileOptions {
+            sourceCompatibility = JavaVersion.VERSION_21
+            targetCompatibility = JavaVersion.VERSION_21
+        }
+
+        packaging {
+            resources {
+                excludes += "/META-INF/LICENSE.md"
+                excludes += "/META-INF/LICENSE-notice.md"
+                excludes += "/META-INF/{AL2.0,LGPL2.1}"
+
+                // Temporary fix for OSGi issue org.jspecify:jspecify:1.0.0 and
+                // com.squareup.okhttp3:logging-interceptor:5.2.1
+                excludes += "META-INF/versions/9/OSGI-INF/MANIFEST.MF"
+            }
+        }
+    }
+
+    // Match Kotlin toolchain to Java target. CI runner JDK is 21 — see
+    // L-2026-04-30-02 in .claude/lessons.md before touching this.
+    extensions.configure(KotlinAndroidProjectExtension::class.java) {
+        jvmToolchain(21)
+    }
+
+    // Required by Mockk's inline mock-maker / byte-buddy agent attach on JDK 21+.
+    tasks.withType(Test::class.java).configureEach {
+        jvmArgs("-XX:+EnableDynamicAgentLoading")
+    }
+}

--- a/build-logic/convention/src/main/kotlin/pm/bam/gamedeals/AndroidCommon.kt
+++ b/build-logic/convention/src/main/kotlin/pm/bam/gamedeals/AndroidCommon.kt
@@ -44,8 +44,6 @@ internal fun Project.configureAndroidCommon(extension: CommonExtension<*, *, *, 
         }
     }
 
-    // Match Kotlin toolchain to Java target. CI runner JDK is 21 — see
-    // L-2026-04-30-02 in .claude/lessons.md before touching this.
     extensions.configure(KotlinAndroidProjectExtension::class.java) {
         jvmToolchain(21)
     }

--- a/build-logic/convention/src/main/kotlin/pm/bam/gamedeals/AndroidFeatureConventionPlugin.kt
+++ b/build-logic/convention/src/main/kotlin/pm/bam/gamedeals/AndroidFeatureConventionPlugin.kt
@@ -1,0 +1,88 @@
+package pm.bam.gamedeals
+
+import com.android.build.gradle.LibraryExtension
+import org.gradle.api.Plugin
+import org.gradle.api.Project
+import org.gradle.api.artifacts.VersionCatalogsExtension
+import org.gradle.kotlin.dsl.configure
+import org.gradle.kotlin.dsl.getByType
+
+/**
+ * Convention plugin for the six "core" `:feature:*` modules
+ * (home, deal, game, giveaways, search, store).
+ *
+ * Composes the library + Compose conventions and applies KSP. Adds the
+ * feature-module-specific defaults: AndroidJUnitRunner test runner and the
+ * Espresso emulator-control test option.
+ *
+ * Also wires the dependencies that *every one of those six* modules needs
+ * (Hilt + Compose + Material3 + Paging + Coil + tracing + the standard test
+ * stack). Module-specific deps (project() references, the small handful of
+ * extras like `androidx.compose.material3.window` callers, …) stay in each
+ * module's build.gradle.kts.
+ *
+ * `:feature:webview` deliberately does NOT use this convention — it has no
+ * Hilt, no Paging and no Coil, so forcing the feature convention onto it
+ * would either add unused deps or splinter the convention's contract.
+ */
+class AndroidFeatureConventionPlugin : Plugin<Project> {
+    override fun apply(target: Project): Unit = with(target) {
+        pluginManager.apply("pm.bam.gamedeals.android.library")
+        pluginManager.apply("pm.bam.gamedeals.android.library.compose")
+        pluginManager.apply("pm.bam.gamedeals.android.ksp")
+
+        extensions.configure<LibraryExtension> {
+            defaultConfig.testInstrumentationRunner =
+                "androidx.test.runner.AndroidJUnitRunner"
+
+            @Suppress("UnstableApiUsage")
+            testOptions.emulatorControl.enable = true
+        }
+
+        val libs = extensions.getByType<VersionCatalogsExtension>().named("libs")
+
+        dependencies.apply {
+            // Universal Android + Material + Compose surface for feature modules.
+            add("implementation", libs.findLibrary("androidx-ktx").get())
+            add("implementation", libs.findLibrary("androidx-appcompat").get())
+            add("implementation", libs.findLibrary("material").get())
+            add("implementation", libs.findLibrary("androidx-compose-navigation").get())
+            add("implementation", libs.findLibrary("androidx-compose-runtime").get())
+            add("implementation", libs.findLibrary("androidx-ui").get())
+            add("implementation", libs.findLibrary("androidx-ui-graphics").get())
+            add("implementation", libs.findLibrary("androidx-ui-tooling").get())
+            add("implementation", libs.findLibrary("androidx-compose-material3").get())
+            add("implementation", libs.findLibrary("androidx-compose-material3-window").get())
+            add("implementation", libs.findLibrary("androidx-compose-material3-adaptive").get())
+
+            // Hilt — every core feature uses Hilt + navigation-compose; the KSP
+            // processors are universal too.
+            add("implementation", libs.findLibrary("hilt-android").get())
+            add("implementation", libs.findLibrary("hilt-navigation-compose").get())
+            add("ksp", libs.findLibrary("hilt-compiler").get())
+            add("ksp", libs.findLibrary("hilt-androidx-compiler").get())
+
+            // Paging + Coil — every core feature consumes paged lists and image
+            // loading; coil-test is included on implementation because the
+            // pre-refactor modules all did so (used by Compose preview fakes).
+            add("implementation", libs.findLibrary("androidx-paging").get())
+            add("implementation", libs.findLibrary("androidx-paging-compose").get())
+            add("implementation", libs.findLibrary("coil").get())
+            add("implementation", libs.findLibrary("coil-compose").get())
+            add("implementation", libs.findLibrary("coil-test").get())
+
+            // Standard JVM unit-test stack used by every core feature.
+            add("testImplementation", libs.findLibrary("junit").get())
+            add("testImplementation", libs.findLibrary("mockk").get())
+            add("testImplementation", libs.findLibrary("coroutines-testing").get())
+
+            // Standard instrumented-test stack used by every core feature.
+            add("androidTestImplementation", libs.findLibrary("mockk-android").get())
+            add("androidTestImplementation", libs.findLibrary("androidx-junit").get())
+            add("androidTestImplementation", libs.findLibrary("androidx-runner").get())
+            add("androidTestImplementation", libs.findLibrary("androidx-espresso-core").get())
+            add("androidTestImplementation", libs.findLibrary("androidx-compose-junit4").get())
+            add("debugImplementation", libs.findLibrary("androidx-compose-test").get())
+        }
+    }
+}

--- a/build-logic/convention/src/main/kotlin/pm/bam/gamedeals/AndroidKspConventionPlugin.kt
+++ b/build-logic/convention/src/main/kotlin/pm/bam/gamedeals/AndroidKspConventionPlugin.kt
@@ -1,0 +1,26 @@
+package pm.bam.gamedeals
+
+import org.gradle.api.Plugin
+import org.gradle.api.Project
+
+/**
+ * Applies KSP for modules that use annotation-processor-style code generation
+ * (Dagger Hilt's compiler, androidx Hilt compiler, Room compiler, etc.).
+ *
+ * Deliberately does NOT apply the Hilt Gradle plugin
+ * (`com.google.dagger.hilt.android`). In the pre-refactor codebase that Gradle
+ * plugin was only applied to `:base` and `:app` — every other module used
+ * Hilt purely through the KSP processor. To keep this PR structural we
+ * preserve that boundary: modules that need the Hilt Gradle plugin continue
+ * to apply it directly in their `build.gradle.kts`.
+ *
+ * Per-module dependency declarations (`hilt-android`, `hilt-compiler`,
+ * `hilt-navigation-compose`, `hilt-androidx-compiler`, `room-compiler`, …)
+ * stay in each module's `build.gradle.kts` because the set varies (e.g.
+ * `:logging` doesn't use `hilt-navigation-compose`).
+ */
+class AndroidKspConventionPlugin : Plugin<Project> {
+    override fun apply(target: Project) {
+        target.pluginManager.apply("com.google.devtools.ksp")
+    }
+}

--- a/build-logic/convention/src/main/kotlin/pm/bam/gamedeals/AndroidLibraryComposeConventionPlugin.kt
+++ b/build-logic/convention/src/main/kotlin/pm/bam/gamedeals/AndroidLibraryComposeConventionPlugin.kt
@@ -1,0 +1,30 @@
+package pm.bam.gamedeals
+
+import com.android.build.gradle.LibraryExtension
+import org.gradle.api.Plugin
+import org.gradle.api.Project
+import org.gradle.kotlin.dsl.configure
+
+/**
+ * Adds Jetpack Compose to a module that already applies an Android library
+ * convention (or `com.android.library` directly).
+ *
+ * Applies the Kotlin Compose Compiler Gradle plugin and flips
+ * `buildFeatures.compose = true`. Under Kotlin 2.x with that plugin applied
+ * `composeOptions.kotlinCompilerExtensionVersion` is unused / ignored — that
+ * dead config is intentionally not carried forward (issue #22 acceptance
+ * criterion).
+ *
+ * Compose runtime / UI / Material3 coordinates stay as per-module dependency
+ * declarations because not every Compose-using module wants the same surface
+ * area (see :common:ui vs :feature:webview).
+ */
+class AndroidLibraryComposeConventionPlugin : Plugin<Project> {
+    override fun apply(target: Project) = with(target) {
+        pluginManager.apply("org.jetbrains.kotlin.plugin.compose")
+
+        extensions.configure<LibraryExtension> {
+            buildFeatures.compose = true
+        }
+    }
+}

--- a/build-logic/convention/src/main/kotlin/pm/bam/gamedeals/AndroidLibraryConventionPlugin.kt
+++ b/build-logic/convention/src/main/kotlin/pm/bam/gamedeals/AndroidLibraryConventionPlugin.kt
@@ -1,0 +1,37 @@
+package pm.bam.gamedeals
+
+import com.android.build.gradle.LibraryExtension
+import org.gradle.api.Plugin
+import org.gradle.api.Project
+import org.gradle.kotlin.dsl.configure
+
+/**
+ * Convention plugin for non-feature Android library modules (e.g. :common, :logging,
+ * :base, :remote, :remote:cheapshark, :remote:gamerpower, :testing).
+ *
+ * Applies the Android library + Kotlin Android plugins and the shared compile /
+ * packaging configuration. Compose and Hilt are NOT applied here — modules that
+ * need those should also apply `pm.bam.gamedeals.android.library.compose` and/or
+ * `pm.bam.gamedeals.android.hilt` (or use the broader `pm.bam.gamedeals.android.feature`
+ * convention).
+ *
+ * Per-module dependency declarations stay in each module's build.gradle.kts; this
+ * plugin intentionally does not auto-add coordinates to keep convention scope tight.
+ */
+class AndroidLibraryConventionPlugin : Plugin<Project> {
+    override fun apply(target: Project) = with(target) {
+        pluginManager.apply("com.android.library")
+        pluginManager.apply("org.jetbrains.kotlin.android")
+
+        extensions.configure<LibraryExtension> {
+            configureAndroidCommon(this)
+
+            buildTypes.named("release").configure {
+                isMinifyEnabled = false
+                proguardFiles(
+                    getDefaultProguardFile("proguard-android-optimize.txt")
+                )
+            }
+        }
+    }
+}

--- a/build-logic/settings.gradle.kts
+++ b/build-logic/settings.gradle.kts
@@ -1,0 +1,17 @@
+@file:Suppress("UnstableApiUsage")
+
+dependencyResolutionManagement {
+    repositories {
+        google()
+        mavenCentral()
+    }
+
+    versionCatalogs {
+        create("libs") {
+            from(files("../gradle/libs.versions.toml"))
+        }
+    }
+}
+
+rootProject.name = "build-logic"
+include(":convention")

--- a/common/build.gradle.kts
+++ b/common/build.gradle.kts
@@ -1,53 +1,15 @@
 plugins {
-    alias(libs.plugins.androidLibrary)
-    alias(libs.plugins.jetbrains.kotlin)
-    alias(libs.plugins.compose)
-    alias(libs.plugins.kotlin.ksp)
+    alias(libs.plugins.gamedeals.android.library)
+    alias(libs.plugins.gamedeals.android.library.compose)
+    alias(libs.plugins.gamedeals.android.ksp)
     alias(libs.plugins.kotlinx.serialization)
 }
 
 android {
     namespace = "pm.bam.gamedeals.common"
-    compileSdk = 36
-
-    defaultConfig {
-        minSdk = 26
-    }
-
-    buildTypes {
-        release {
-            isMinifyEnabled = false
-            proguardFiles(getDefaultProguardFile("proguard-android-optimize.txt"))
-        }
-    }
-    buildFeatures {
-        compose = true
-    }
-    compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_21
-        targetCompatibility = JavaVersion.VERSION_21
-    }
-    kotlin {
-        jvmToolchain(21)
-    }
-    packaging {
-        resources {
-
-            excludes += "/META-INF/LICENSE.md"
-            excludes += "/META-INF/LICENSE-notice.md"
-            excludes += "/META-INF/{AL2.0,LGPL2.1}"
-
-            // Temporary fix for OSGi issue org.jspecify:jspecify:1.0.0 and com.squareup.okhttp3:logging-interceptor:5.2.1
-            excludes += "META-INF/versions/9/OSGI-INF/MANIFEST.MF"
-        }
-    }
-    tasks.withType<Test> {
-        jvmArgs = listOf("-XX:+EnableDynamicAgentLoading")
-    }
 }
 
 dependencies {
-
     // KotlinX Serialization - api so that other modules can use this dependency
     api(libs.kotlinx)
     api(libs.kotlinx.properties)

--- a/common/ui/build.gradle.kts
+++ b/common/ui/build.gradle.kts
@@ -1,54 +1,13 @@
 plugins {
-    alias(libs.plugins.androidLibrary)
-    alias(libs.plugins.jetbrains.kotlin)
-    alias(libs.plugins.compose)
+    alias(libs.plugins.gamedeals.android.library)
+    alias(libs.plugins.gamedeals.android.library.compose)
 }
 
 android {
     namespace = "pm.bam.gamedeals.common.ui"
-    compileSdk = 36
-
-    defaultConfig {
-        minSdk = 26
-    }
-
-    buildTypes {
-        release {
-            isMinifyEnabled = false
-            proguardFiles(getDefaultProguardFile("proguard-android-optimize.txt"))
-        }
-    }
-    compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_21
-        targetCompatibility = JavaVersion.VERSION_21
-    }
-    kotlin {
-        jvmToolchain(21)
-    }
-    buildFeatures {
-        compose = true
-    }
-    composeOptions {
-        kotlinCompilerExtensionVersion = "1.5.11"
-    }
-    packaging {
-        resources {
-
-            excludes += "/META-INF/LICENSE.md"
-            excludes += "/META-INF/LICENSE-notice.md"
-            excludes += "/META-INF/{AL2.0,LGPL2.1}"
-
-            // Temporary fix for OSGi issue org.jspecify:jspecify:1.0.0 and com.squareup.okhttp3:logging-interceptor:5.2.1
-            excludes += "META-INF/versions/9/OSGI-INF/MANIFEST.MF"
-        }
-    }
-    tasks.withType<Test> {
-        jvmArgs = listOf("-XX:+EnableDynamicAgentLoading")
-    }
 }
 
 dependencies {
-
     implementation(project(":logging"))
     implementation(project(":common"))
     implementation(project(":domain"))

--- a/domain/build.gradle.kts
+++ b/domain/build.gradle.kts
@@ -1,56 +1,15 @@
 plugins {
-    alias(libs.plugins.androidLibrary)
-    alias(libs.plugins.jetbrains.kotlin)
-    alias(libs.plugins.compose)
-    alias(libs.plugins.kotlin.ksp)
+    alias(libs.plugins.gamedeals.android.library)
+    alias(libs.plugins.gamedeals.android.library.compose)
+    alias(libs.plugins.gamedeals.android.ksp)
     alias(libs.plugins.kotlinx.serialization)
 }
 
 android {
     namespace = "pm.bam.gamedeals.domain"
-    compileSdk = 36
-
-    defaultConfig {
-        minSdk = 26
-    }
-
-    buildTypes {
-        release {
-            isMinifyEnabled = false
-            proguardFiles(getDefaultProguardFile("proguard-android-optimize.txt"))
-        }
-    }
-    compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_21
-        targetCompatibility = JavaVersion.VERSION_21
-    }
-    kotlin {
-        jvmToolchain(21)
-    }
-    buildFeatures {
-        compose = true
-    }
-    composeOptions {
-        kotlinCompilerExtensionVersion = "1.5.11"
-    }
-    packaging {
-        resources {
-
-            excludes += "/META-INF/LICENSE.md"
-            excludes += "/META-INF/LICENSE-notice.md"
-            excludes += "/META-INF/{AL2.0,LGPL2.1}"
-
-            // Temporary fix for OSGi issue org.jspecify:jspecify:1.0.0 and com.squareup.okhttp3:logging-interceptor:5.2.1
-            excludes += "META-INF/versions/9/OSGI-INF/MANIFEST.MF"
-        }
-    }
-    tasks.withType<Test> {
-        jvmArgs = listOf("-XX:+EnableDynamicAgentLoading")
-    }
 }
 
 dependencies {
-
     implementation(project(":logging"))
     implementation(project(":common"))
 

--- a/feature/deal/build.gradle.kts
+++ b/feature/deal/build.gradle.kts
@@ -1,98 +1,18 @@
 plugins {
-    alias(libs.plugins.androidLibrary)
-    alias(libs.plugins.jetbrains.kotlin)
-    alias(libs.plugins.kotlin.ksp)
-    alias(libs.plugins.compose)
+    alias(libs.plugins.gamedeals.android.feature)
 }
 
 android {
     namespace = "pm.bam.gamedeals.feature.deal"
-    compileSdk = 36
-
-    defaultConfig {
-        minSdk = 26
-
-        testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
-    }
-
-    buildTypes {
-        release {
-            isMinifyEnabled = false
-            proguardFiles(getDefaultProguardFile("proguard-android-optimize.txt"))
-        }
-    }
-    compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_21
-        targetCompatibility = JavaVersion.VERSION_21
-    }
-    kotlin {
-        jvmToolchain(21)
-    }
-    buildFeatures {
-        compose = true
-    }
-    composeOptions {
-        kotlinCompilerExtensionVersion = "1.5.11"
-    }
-    packaging {
-        resources {
-            excludes += "/META-INF/LICENSE.md"
-            excludes += "/META-INF/LICENSE-notice.md"
-            excludes += "/META-INF/{AL2.0,LGPL2.1}"
-
-            // Temporary fix for OSGi issue org.jspecify:jspecify:1.0.0 and com.squareup.okhttp3:logging-interceptor:5.2.1
-            excludes += "META-INF/versions/9/OSGI-INF/MANIFEST.MF"
-        }
-    }
-    tasks.withType<Test> {
-        jvmArgs = listOf("-XX:+EnableDynamicAgentLoading")
-    }
 }
 
 dependencies {
-
     implementation(project(":common"))
     implementation(project(":common:ui"))
     implementation(project(":logging"))
     implementation(project(":domain"))
     implementation(project(":feature:webview"))
 
-    implementation(libs.androidx.ktx)
-    implementation(libs.androidx.appcompat)
-    implementation(libs.material)
-    implementation(libs.androidx.compose.navigation)
-    implementation(libs.androidx.compose.runtime)
-
-    implementation(libs.hilt.android)
-    implementation(libs.hilt.navigation.compose)
-    ksp(libs.hilt.compiler)
-    ksp(libs.hilt.androidx.compiler)
-
-    implementation(libs.androidx.ui)
-    implementation(libs.androidx.ui.graphics)
-    implementation(libs.androidx.ui.tooling)
-    implementation(libs.androidx.ui.tooling)
-    implementation(libs.androidx.compose.material3)
-    implementation(libs.androidx.compose.material3.window)
-    implementation(libs.androidx.compose.material3.adaptive)
-
-    implementation(libs.androidx.paging)
-    implementation(libs.androidx.paging.compose)
-
-    implementation(libs.coil)
-    implementation(libs.coil.compose)
-    implementation(libs.coil.test)
-
     testImplementation(project(":testing"))
-    testImplementation(libs.junit)
-    testImplementation(libs.mockk)
     testImplementation(libs.core.testing)
-    testImplementation(libs.coroutines.testing)
-
-    androidTestImplementation(libs.mockk.android)
-    androidTestImplementation(libs.androidx.junit)
-    androidTestImplementation(libs.androidx.runner)
-    androidTestImplementation(libs.androidx.espresso.core)
-    androidTestImplementation(libs.androidx.compose.junit4)
-    debugImplementation(libs.androidx.compose.test)
 }

--- a/feature/game/build.gradle.kts
+++ b/feature/game/build.gradle.kts
@@ -1,112 +1,24 @@
 plugins {
-    alias(libs.plugins.androidLibrary)
-    alias(libs.plugins.jetbrains.kotlin)
-    alias(libs.plugins.kotlin.ksp)
-    alias(libs.plugins.compose)
+    alias(libs.plugins.gamedeals.android.feature)
 }
 
 android {
     namespace = "pm.bam.gamedeals.feature.game"
-    compileSdk = 36
-
-    defaultConfig {
-        minSdk = 26
-
-        testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
-    }
-
-    buildTypes {
-        release {
-            isMinifyEnabled = false
-            proguardFiles(getDefaultProguardFile("proguard-android-optimize.txt"))
-        }
-    }
-    compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_21
-        targetCompatibility = JavaVersion.VERSION_21
-    }
-    kotlin {
-        jvmToolchain(21)
-    }
-    buildFeatures {
-        compose = true
-    }
-    composeOptions {
-        kotlinCompilerExtensionVersion = "1.5.11"
-    }
-    packaging {
-        resources {
-            excludes += "/META-INF/LICENSE.md"
-            excludes += "/META-INF/LICENSE-notice.md"
-            excludes += "/META-INF/{AL2.0,LGPL2.1}"
-
-            // Temporary fix for OSGi issue org.jspecify:jspecify:1.0.0 and com.squareup.okhttp3:logging-interceptor:5.2.1
-            excludes += "META-INF/versions/9/OSGI-INF/MANIFEST.MF"
-        }
-    }
-    tasks.withType<Test> {
-        jvmArgs = listOf("-XX:+EnableDynamicAgentLoading")
-    }
-
-    @Suppress("UnstableApiUsage")
-    testOptions {
-
-        // This allows Espresso test to change device configurations, like Orientation during testing.
-        emulatorControl.enable = true
-    }
 }
 
 dependencies {
-
     implementation(project(":logging"))
     implementation(project(":domain"))
     implementation(project(":common"))
     implementation(project(":common:ui"))
     implementation(project(":feature:deal"))
-
-    implementation(libs.androidx.ktx)
-    implementation(libs.androidx.appcompat)
-    implementation(libs.material)
     implementation(libs.compose.material.icons)
-    implementation(libs.androidx.compose.navigation)
-    implementation(libs.androidx.compose.runtime)
-
-    implementation(libs.hilt.android)
-    implementation(libs.hilt.navigation.compose)
-    ksp(libs.hilt.compiler)
-    ksp(libs.hilt.androidx.compiler)
-
-    implementation(libs.androidx.ui)
-    implementation(libs.androidx.ui.graphics)
-    implementation(libs.androidx.ui.tooling)
-    implementation(libs.androidx.compose.material3)
-    implementation(libs.androidx.compose.material3.window)
-    implementation(libs.androidx.compose.material3.adaptive)
-
-    implementation(libs.androidx.paging)
-    implementation(libs.androidx.paging.compose)
-
-    implementation(libs.coil)
-    implementation(libs.coil.compose)
-    implementation(libs.coil.test)
-
     implementation(libs.androidx.tracing) {
-        because("Tracing is used to monitor the performance of the app. " +
-                "Specifically needed because of libs.androidx.espresso.device import. " +
-                "See: https://github.com/android/android-test/issues/1755#issuecomment-1523810698")
+        because("Pulled in by libs.androidx.espresso.device — see " +
+                "https://github.com/android/android-test/issues/1755#issuecomment-1523810698")
     }
 
     testImplementation(project(":testing"))
-    testImplementation(libs.junit)
-    testImplementation(libs.mockk)
     testImplementation(libs.core.testing)
-    testImplementation(libs.coroutines.testing)
-
-    androidTestImplementation(libs.mockk.android)
-    androidTestImplementation(libs.androidx.junit)
-    androidTestImplementation(libs.androidx.runner)
-    androidTestImplementation(libs.androidx.espresso.core)
     androidTestImplementation(libs.androidx.espresso.device)
-    androidTestImplementation(libs.androidx.compose.junit4)
-    debugImplementation(libs.androidx.compose.test)
 }

--- a/feature/giveaways/build.gradle.kts
+++ b/feature/giveaways/build.gradle.kts
@@ -1,97 +1,17 @@
 plugins {
-    alias(libs.plugins.androidLibrary)
-    alias(libs.plugins.jetbrains.kotlin)
-    alias(libs.plugins.kotlin.ksp)
-    alias(libs.plugins.compose)
+    alias(libs.plugins.gamedeals.android.feature)
 }
 
 android {
     namespace = "pm.bam.gamedeals.feature.giveaways"
-    compileSdk = 36
-
-    defaultConfig {
-        minSdk = 26
-
-        testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
-    }
-
-    buildTypes {
-        release {
-            isMinifyEnabled = false
-            proguardFiles(getDefaultProguardFile("proguard-android-optimize.txt"))
-        }
-    }
-    compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_21
-        targetCompatibility = JavaVersion.VERSION_21
-    }
-    kotlin {
-        jvmToolchain(21)
-    }
-    buildFeatures {
-        compose = true
-    }
-    composeOptions {
-        kotlinCompilerExtensionVersion = "1.5.11"
-    }
-    packaging {
-        resources {
-            excludes += "/META-INF/LICENSE.md"
-            excludes += "/META-INF/LICENSE-notice.md"
-            excludes += "/META-INF/{AL2.0,LGPL2.1}"
-
-            // Temporary fix for OSGi issue org.jspecify:jspecify:1.0.0 and com.squareup.okhttp3:logging-interceptor:5.2.1
-            excludes += "META-INF/versions/9/OSGI-INF/MANIFEST.MF"
-        }
-    }
-    tasks.withType<Test> {
-        jvmArgs = listOf("-XX:+EnableDynamicAgentLoading")
-    }
 }
 
 dependencies {
-
     implementation(project(":logging"))
     implementation(project(":domain"))
     implementation(project(":common"))
     implementation(project(":common:ui"))
-
-    implementation(libs.androidx.ktx)
-    implementation(libs.androidx.appcompat)
-    implementation(libs.material)
     implementation(libs.compose.material.icons)
-    implementation(libs.androidx.compose.navigation)
-    implementation(libs.androidx.compose.runtime)
-
-    implementation(libs.hilt.android)
-    implementation(libs.hilt.navigation.compose)
-    ksp(libs.hilt.compiler)
-    ksp(libs.hilt.androidx.compiler)
-
-    implementation(libs.androidx.ui)
-    implementation(libs.androidx.ui.graphics)
-    implementation(libs.androidx.ui.tooling)
-    implementation(libs.androidx.ui.tooling)
-    implementation(libs.androidx.compose.material3)
-    implementation(libs.androidx.compose.material3.window)
-    implementation(libs.androidx.compose.material3.adaptive)
-
-    implementation(libs.androidx.paging)
-    implementation(libs.androidx.paging.compose)
-
-    implementation(libs.coil)
-    implementation(libs.coil.compose)
-    implementation(libs.coil.test)
 
     testImplementation(project(":testing"))
-    testImplementation(libs.junit)
-    testImplementation(libs.mockk)
-    testImplementation(libs.coroutines.testing)
-
-    androidTestImplementation(libs.mockk.android)
-    androidTestImplementation(libs.androidx.junit)
-    androidTestImplementation(libs.androidx.runner)
-    androidTestImplementation(libs.androidx.espresso.core)
-    androidTestImplementation(libs.androidx.compose.junit4)
-    debugImplementation(libs.androidx.compose.test)
 }

--- a/feature/home/build.gradle.kts
+++ b/feature/home/build.gradle.kts
@@ -1,110 +1,22 @@
 plugins {
-    alias(libs.plugins.androidLibrary)
-    alias(libs.plugins.jetbrains.kotlin)
-    alias(libs.plugins.kotlin.ksp)
-    alias(libs.plugins.compose)
+    alias(libs.plugins.gamedeals.android.feature)
 }
 
 android {
     namespace = "pm.bam.gamedeals.feature.home"
-    compileSdk = 36
-
-    defaultConfig {
-        minSdk = 26
-
-        testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
-    }
-
-    buildTypes {
-        release {
-            isMinifyEnabled = false
-            proguardFiles(getDefaultProguardFile("proguard-android-optimize.txt"))
-        }
-    }
-    compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_21
-        targetCompatibility = JavaVersion.VERSION_21
-    }
-    kotlin {
-        jvmToolchain(21)
-    }
-    buildFeatures {
-        compose = true
-    }
-    composeOptions {
-        kotlinCompilerExtensionVersion = "1.5.11"
-    }
-    packaging {
-        resources {
-            excludes += "/META-INF/LICENSE.md"
-            excludes += "/META-INF/LICENSE-notice.md"
-            excludes += "/META-INF/{AL2.0,LGPL2.1}"
-
-            // Temporary fix for OSGi issue org.jspecify:jspecify:1.0.0 and com.squareup.okhttp3:logging-interceptor:5.2.1
-            excludes += "META-INF/versions/9/OSGI-INF/MANIFEST.MF"
-        }
-    }
-    tasks.withType<Test> {
-        jvmArgs = listOf("-XX:+EnableDynamicAgentLoading")
-    }
-
-    @Suppress("UnstableApiUsage")
-    testOptions {
-
-        // This allows Espresso test to change device configurations, like Orientation during testing.
-        emulatorControl.enable = true
-    }
 }
 
 dependencies {
-
     implementation(project(":logging"))
     implementation(project(":domain"))
     implementation(project(":common"))
     implementation(project(":common:ui"))
-
-    implementation(libs.androidx.ktx)
-    implementation(libs.androidx.appcompat)
-    implementation(libs.material)
     implementation(libs.compose.material.icons)
-    implementation(libs.androidx.compose.navigation)
-    implementation(libs.androidx.compose.runtime)
-
-    implementation(libs.hilt.android)
-    implementation(libs.hilt.navigation.compose)
-    ksp(libs.hilt.compiler)
-    ksp(libs.hilt.androidx.compiler)
-
-    implementation(libs.androidx.ui)
-    implementation(libs.androidx.ui.graphics)
-    implementation(libs.androidx.ui.tooling)
-    implementation(libs.androidx.compose.material3)
-    implementation(libs.androidx.compose.material3.window)
-    implementation(libs.androidx.compose.material3.adaptive)
-
-    implementation(libs.androidx.paging)
-    implementation(libs.androidx.paging.compose)
-
-    implementation(libs.coil)
-    implementation(libs.coil.compose)
-    implementation(libs.coil.test)
-
     implementation(libs.androidx.tracing) {
-        because("Tracing is used to monitor the performance of the app. " +
-                "Specifically needed because of libs.androidx.espresso.device import. " +
-                "See: https://github.com/android/android-test/issues/1755#issuecomment-1523810698")
+        because("Pulled in by libs.androidx.espresso.device — see " +
+                "https://github.com/android/android-test/issues/1755#issuecomment-1523810698")
     }
 
     testImplementation(project(":testing"))
-    testImplementation(libs.junit)
-    testImplementation(libs.mockk)
-    testImplementation(libs.coroutines.testing)
-
-    androidTestImplementation(libs.mockk.android)
-    androidTestImplementation(libs.androidx.junit)
-    androidTestImplementation(libs.androidx.runner)
-    androidTestImplementation(libs.androidx.espresso.core)
     androidTestImplementation(libs.androidx.espresso.device)
-    androidTestImplementation(libs.androidx.compose.junit4)
-    debugImplementation(libs.androidx.compose.test)
 }

--- a/feature/search/build.gradle.kts
+++ b/feature/search/build.gradle.kts
@@ -1,96 +1,17 @@
 plugins {
-    alias(libs.plugins.androidLibrary)
-    alias(libs.plugins.jetbrains.kotlin)
-    alias(libs.plugins.kotlin.ksp)
-    alias(libs.plugins.compose)
+    alias(libs.plugins.gamedeals.android.feature)
 }
 
 android {
     namespace = "pm.bam.gamedeals.feature.search"
-    compileSdk = 36
-
-    defaultConfig {
-        minSdk = 26
-
-        testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
-    }
-
-    buildTypes {
-        release {
-            isMinifyEnabled = false
-            proguardFiles(getDefaultProguardFile("proguard-android-optimize.txt"))
-        }
-    }
-    compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_21
-        targetCompatibility = JavaVersion.VERSION_21
-    }
-    kotlin {
-        jvmToolchain(21)
-    }
-    buildFeatures {
-        compose = true
-    }
-    composeOptions {
-        kotlinCompilerExtensionVersion = "1.5.11"
-    }
-    packaging {
-        resources {
-            excludes += "/META-INF/LICENSE.md"
-            excludes += "/META-INF/LICENSE-notice.md"
-            excludes += "/META-INF/{AL2.0,LGPL2.1}"
-
-            // Temporary fix for OSGi issue org.jspecify:jspecify:1.0.0 and com.squareup.okhttp3:logging-interceptor:5.2.1
-            excludes += "META-INF/versions/9/OSGI-INF/MANIFEST.MF"
-        }
-    }
-    tasks.withType<Test> {
-        jvmArgs = listOf("-XX:+EnableDynamicAgentLoading")
-    }
 }
 
 dependencies {
-
     implementation(project(":logging"))
     implementation(project(":domain"))
     implementation(project(":common"))
     implementation(project(":common:ui"))
-
-    implementation(libs.androidx.ktx)
-    implementation(libs.androidx.appcompat)
-    implementation(libs.material)
     implementation(libs.compose.material.icons)
-    implementation(libs.androidx.compose.navigation)
-    implementation(libs.androidx.compose.runtime)
-
-    implementation(libs.hilt.android)
-    implementation(libs.hilt.navigation.compose)
-    ksp(libs.hilt.compiler)
-    ksp(libs.hilt.androidx.compiler)
-
-    implementation(libs.androidx.ui)
-    implementation(libs.androidx.ui.graphics)
-    implementation(libs.androidx.ui.tooling)
-    implementation(libs.androidx.compose.material3)
-    implementation(libs.androidx.compose.material3.window)
-    implementation(libs.androidx.compose.material3.adaptive)
-
-    implementation(libs.androidx.paging)
-    implementation(libs.androidx.paging.compose)
-
-    implementation(libs.coil)
-    implementation(libs.coil.compose)
-    implementation(libs.coil.test)
 
     testImplementation(project(":testing"))
-    testImplementation(libs.junit)
-    testImplementation(libs.mockk)
-    testImplementation(libs.coroutines.testing)
-
-    androidTestImplementation(libs.mockk.android)
-    androidTestImplementation(libs.androidx.junit)
-    androidTestImplementation(libs.androidx.runner)
-    androidTestImplementation(libs.androidx.espresso.core)
-    androidTestImplementation(libs.androidx.compose.junit4)
-    debugImplementation(libs.androidx.compose.test)
 }

--- a/feature/store/build.gradle.kts
+++ b/feature/store/build.gradle.kts
@@ -1,97 +1,17 @@
 plugins {
-    alias(libs.plugins.androidLibrary)
-    alias(libs.plugins.jetbrains.kotlin)
-    alias(libs.plugins.kotlin.ksp)
-    alias(libs.plugins.compose)
+    alias(libs.plugins.gamedeals.android.feature)
 }
 
 android {
     namespace = "pm.bam.gamedeals.feature.store"
-    compileSdk = 36
-
-    defaultConfig {
-        minSdk = 26
-
-        testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
-    }
-
-    buildTypes {
-        release {
-            isMinifyEnabled = false
-            proguardFiles(getDefaultProguardFile("proguard-android-optimize.txt"))
-        }
-    }
-    compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_21
-        targetCompatibility = JavaVersion.VERSION_21
-    }
-    kotlin {
-        jvmToolchain(21)
-    }
-    buildFeatures {
-        compose = true
-    }
-    composeOptions {
-        kotlinCompilerExtensionVersion = "1.5.11"
-    }
-    packaging {
-        resources {
-            excludes += "/META-INF/LICENSE.md"
-            excludes += "/META-INF/LICENSE-notice.md"
-            excludes += "/META-INF/{AL2.0,LGPL2.1}"
-
-            // Temporary fix for OSGi issue org.jspecify:jspecify:1.0.0 and com.squareup.okhttp3:logging-interceptor:5.2.1
-            excludes += "META-INF/versions/9/OSGI-INF/MANIFEST.MF"
-        }
-    }
-    tasks.withType<Test> {
-        jvmArgs = listOf("-XX:+EnableDynamicAgentLoading")
-    }
 }
 
 dependencies {
-
     implementation(project(":logging"))
     implementation(project(":domain"))
     implementation(project(":common"))
     implementation(project(":common:ui"))
-
-    implementation(libs.androidx.ktx)
-    implementation(libs.androidx.appcompat)
-    implementation(libs.material)
     implementation(libs.compose.material.icons)
-    implementation(libs.androidx.compose.navigation)
-    implementation(libs.androidx.compose.runtime)
-
-    implementation(libs.hilt.android)
-    implementation(libs.hilt.navigation.compose)
-    ksp(libs.hilt.compiler)
-    ksp(libs.hilt.androidx.compiler)
-
-    implementation(libs.androidx.ui)
-    implementation(libs.androidx.ui.graphics)
-    implementation(libs.androidx.ui.tooling)
-    implementation(libs.androidx.ui.tooling)
-    implementation(libs.androidx.compose.material3)
-    implementation(libs.androidx.compose.material3.window)
-    implementation(libs.androidx.compose.material3.adaptive)
-
-    implementation(libs.androidx.paging)
-    implementation(libs.androidx.paging.compose)
-
-    implementation(libs.coil)
-    implementation(libs.coil.compose)
-    implementation(libs.coil.test)
 
     testImplementation(project(":testing"))
-    testImplementation(libs.junit)
-    testImplementation(libs.mockk)
-    testImplementation(libs.coroutines.testing)
-
-    androidTestImplementation(libs.mockk.android)
-    androidTestImplementation(libs.androidx.junit)
-    androidTestImplementation(libs.androidx.runner)
-    androidTestImplementation(libs.androidx.espresso.core)
-    androidTestImplementation(libs.androidx.compose.junit4)
-    debugImplementation(libs.androidx.compose.test)
 }

--- a/feature/webview/build.gradle.kts
+++ b/feature/webview/build.gradle.kts
@@ -1,59 +1,20 @@
 plugins {
-    alias(libs.plugins.androidLibrary)
-    alias(libs.plugins.jetbrains.kotlin)
-    alias(libs.plugins.compose)
+    alias(libs.plugins.gamedeals.android.library)
+    alias(libs.plugins.gamedeals.android.library.compose)
 }
 
 android {
     namespace = "pm.bam.gamedeals.feature.webview"
-    compileSdk = 36
 
     defaultConfig {
-        minSdk = 26
-
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
-    }
-
-    buildTypes {
-        release {
-            isMinifyEnabled = false
-            proguardFiles(getDefaultProguardFile("proguard-android-optimize.txt"))
-        }
-    }
-    compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_21
-        targetCompatibility = JavaVersion.VERSION_21
-    }
-    kotlin {
-        jvmToolchain(21)
-    }
-    buildFeatures {
-        compose = true
-    }
-    composeOptions {
-        kotlinCompilerExtensionVersion = "1.5.11"
-    }
-    packaging {
-        resources {
-            excludes += "/META-INF/LICENSE.md"
-            excludes += "/META-INF/LICENSE-notice.md"
-            excludes += "/META-INF/{AL2.0,LGPL2.1}"
-
-            // Temporary fix for OSGi issue org.jspecify:jspecify:1.0.0 and com.squareup.okhttp3:logging-interceptor:5.2.1
-            excludes += "META-INF/versions/9/OSGI-INF/MANIFEST.MF"
-        }
-    }
-    tasks.withType<Test> {
-        jvmArgs = listOf("-XX:+EnableDynamicAgentLoading")
     }
 }
 
 dependencies {
-
     implementation(project(":logging"))
     implementation(project(":common"))
     implementation(project(":common:ui"))
-
 
     implementation(libs.androidx.ktx)
     implementation(libs.androidx.appcompat)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -140,6 +140,14 @@ androidx-compose-junit4 = { group = "androidx.compose.ui", name = "ui-test-junit
 androidx-compose-test = { group = "androidx.compose.ui", name = "ui-test-manifest", version.ref = "ui-test-junit4" }
 okhttp-mockwebserver = { group = "com.squareup.okhttp3", name = "mockwebserver", version.ref = "okhttp" }
 
+# Build-logic convention-plugin classpath deps.
+# These resolve the Gradle plugin artifacts so precompiled convention plugins
+# can `pluginManager.apply("...")` them by id at runtime.
+android-gradle-plugin = { group = "com.android.tools.build", name = "gradle", version.ref = "android-gradle-plugin" }
+kotlin-gradle-plugin = { group = "org.jetbrains.kotlin", name = "kotlin-gradle-plugin", version.ref = "jetbrains-kotlin-plugin" }
+ksp-gradle-plugin = { group = "com.google.devtools.ksp", name = "com.google.devtools.ksp.gradle.plugin", version.ref = "google-ksp-plugin" }
+compose-gradle-plugin = { group = "org.jetbrains.kotlin", name = "compose-compiler-gradle-plugin", version.ref = "jetbrains-kotlin-plugin" }
+
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "android-gradle-plugin" }
@@ -153,3 +161,10 @@ kotlinx-serialization = { id = "org.jetbrains.kotlin.plugin.serialization", vers
 firebase-performance = { id = "com.google.firebase.firebase-perf", version.ref = "firebase-performance-plugin" }
 google-services = { id = "com.google.gms.google-services", version.ref = "google-services-plugin" }
 firebase-crashlytics = { id = "com.google.firebase.crashlytics", version.ref = "firebase-crashlytics-plugin" }
+
+# Convention plugins (registered by the build-logic included build).
+gamedeals-android-library = { id = "pm.bam.gamedeals.android.library" }
+gamedeals-android-library-compose = { id = "pm.bam.gamedeals.android.library.compose" }
+gamedeals-android-ksp = { id = "pm.bam.gamedeals.android.ksp" }
+gamedeals-android-feature = { id = "pm.bam.gamedeals.android.feature" }
+gamedeals-android-application = { id = "pm.bam.gamedeals.android.application" }

--- a/logging/build.gradle.kts
+++ b/logging/build.gradle.kts
@@ -1,48 +1,13 @@
 plugins {
-    alias(libs.plugins.androidLibrary)
-    alias(libs.plugins.jetbrains.kotlin)
-    alias(libs.plugins.kotlin.ksp)
+    alias(libs.plugins.gamedeals.android.library)
+    alias(libs.plugins.gamedeals.android.ksp)
 }
 
 android {
     namespace = "pm.bam.gamedeals.logging"
-    compileSdk = 36
-
-    defaultConfig {
-        minSdk = 26
-    }
-
-    buildTypes {
-        release {
-            isMinifyEnabled = false
-            proguardFiles(getDefaultProguardFile("proguard-android-optimize.txt"))
-        }
-    }
-    compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_21
-        targetCompatibility = JavaVersion.VERSION_21
-    }
-    kotlin {
-        jvmToolchain(21)
-    }
-    packaging {
-        resources {
-
-            excludes += "/META-INF/LICENSE.md"
-            excludes += "/META-INF/LICENSE-notice.md"
-            excludes += "/META-INF/{AL2.0,LGPL2.1}"
-
-            // Temporary fix for OSGi issue org.jspecify:jspecify:1.0.0 and com.squareup.okhttp3:logging-interceptor:5.2.1
-            excludes += "META-INF/versions/9/OSGI-INF/MANIFEST.MF"
-        }
-    }
-    tasks.withType<Test> {
-        jvmArgs = listOf("-XX:+EnableDynamicAgentLoading")
-    }
 }
 
 dependencies {
-
     implementation(libs.androidx.ktx)
     implementation(libs.androidx.appcompat)
     implementation(libs.material)

--- a/remote/build.gradle.kts
+++ b/remote/build.gradle.kts
@@ -1,53 +1,18 @@
 plugins {
-    alias(libs.plugins.androidLibrary)
-    alias(libs.plugins.jetbrains.kotlin)
-    alias(libs.plugins.kotlin.ksp)
+    alias(libs.plugins.gamedeals.android.library)
+    alias(libs.plugins.gamedeals.android.ksp)
     alias(libs.plugins.kotlinx.serialization)
 }
 
 android {
     namespace = "pm.bam.gamedeals.remote"
-    compileSdk = 36
-
-    defaultConfig {
-        minSdk = 26
-    }
 
     buildFeatures {
-        buildConfig = true // Enable by adding below line for a module that needs it
-    }
-
-    buildTypes {
-        release {
-            isMinifyEnabled = false
-            proguardFiles(getDefaultProguardFile("proguard-android-optimize.txt"))
-        }
-    }
-    compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_21
-        targetCompatibility = JavaVersion.VERSION_21
-    }
-    kotlin {
-        jvmToolchain(21)
-    }
-    packaging {
-        resources {
-
-            excludes += "/META-INF/LICENSE.md"
-            excludes += "/META-INF/LICENSE-notice.md"
-            excludes += "/META-INF/{AL2.0,LGPL2.1}"
-
-            // Temporary fix for OSGi issue org.jspecify:jspecify:1.0.0 and com.squareup.okhttp3:logging-interceptor:5.2.1
-            excludes += "META-INF/versions/9/OSGI-INF/MANIFEST.MF"
-        }
-    }
-    tasks.withType<Test> {
-        jvmArgs = listOf("-XX:+EnableDynamicAgentLoading")
+        buildConfig = true
     }
 }
 
 dependencies {
-
     implementation(project(":logging"))
     implementation(project(":common"))
 

--- a/remote/cheapshark/build.gradle.kts
+++ b/remote/cheapshark/build.gradle.kts
@@ -1,53 +1,18 @@
 plugins {
-    alias(libs.plugins.androidLibrary)
-    alias(libs.plugins.jetbrains.kotlin)
-    alias(libs.plugins.kotlin.ksp)
+    alias(libs.plugins.gamedeals.android.library)
+    alias(libs.plugins.gamedeals.android.ksp)
     alias(libs.plugins.kotlinx.serialization)
 }
 
 android {
     namespace = "pm.bam.gamedeals.remote.cheapshark"
-    compileSdk = 36
-
-    defaultConfig {
-        minSdk = 26
-    }
 
     buildFeatures {
-        buildConfig = true // Enable by adding below line for a module that needs it
-    }
-
-    buildTypes {
-        release {
-            isMinifyEnabled = false
-            proguardFiles(getDefaultProguardFile("proguard-android-optimize.txt"))
-        }
-    }
-    compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_21
-        targetCompatibility = JavaVersion.VERSION_21
-    }
-    kotlin {
-        jvmToolchain(21)
-    }
-    packaging {
-        resources {
-
-            excludes += "/META-INF/LICENSE.md"
-            excludes += "/META-INF/LICENSE-notice.md"
-            excludes += "/META-INF/{AL2.0,LGPL2.1}"
-
-            // Temporary fix for OSGi issue org.jspecify:jspecify:1.0.0 and com.squareup.okhttp3:logging-interceptor:5.2.1
-            excludes += "META-INF/versions/9/OSGI-INF/MANIFEST.MF"
-        }
-    }
-    tasks.withType<Test> {
-        jvmArgs = listOf("-XX:+EnableDynamicAgentLoading")
+        buildConfig = true
     }
 }
 
 dependencies {
-
     implementation(project(":remote"))
     implementation(project(":logging"))
     implementation(project(":common"))

--- a/remote/gamerpower/build.gradle.kts
+++ b/remote/gamerpower/build.gradle.kts
@@ -1,53 +1,18 @@
 plugins {
-    alias(libs.plugins.androidLibrary)
-    alias(libs.plugins.jetbrains.kotlin)
-    alias(libs.plugins.kotlin.ksp)
+    alias(libs.plugins.gamedeals.android.library)
+    alias(libs.plugins.gamedeals.android.ksp)
     alias(libs.plugins.kotlinx.serialization)
 }
 
 android {
     namespace = "pm.bam.gamedeals.remote.gamerpower"
-    compileSdk = 36
-
-    defaultConfig {
-        minSdk = 26
-    }
 
     buildFeatures {
-        buildConfig = true // Enable by adding below line for a module that needs it
-    }
-
-    buildTypes {
-        release {
-            isMinifyEnabled = false
-            proguardFiles(getDefaultProguardFile("proguard-android-optimize.txt"))
-        }
-    }
-    compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_21
-        targetCompatibility = JavaVersion.VERSION_21
-    }
-    kotlin {
-        jvmToolchain(21)
-    }
-    packaging {
-        resources {
-
-            excludes += "/META-INF/LICENSE.md"
-            excludes += "/META-INF/LICENSE-notice.md"
-            excludes += "/META-INF/{AL2.0,LGPL2.1}"
-
-            // Temporary fix for OSGi issue org.jspecify:jspecify:1.0.0 and com.squareup.okhttp3:logging-interceptor:5.2.1
-            excludes += "META-INF/versions/9/OSGI-INF/MANIFEST.MF"
-        }
-    }
-    tasks.withType<Test> {
-        jvmArgs = listOf("-XX:+EnableDynamicAgentLoading")
+        buildConfig = true
     }
 }
 
 dependencies {
-
     implementation(project(":remote"))
     implementation(project(":logging"))
     implementation(project(":common"))

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,6 +1,7 @@
 
 
 pluginManagement {
+    includeBuild("build-logic")
     repositories {
         google()
         mavenCentral()

--- a/testing/build.gradle.kts
+++ b/testing/build.gradle.kts
@@ -1,54 +1,22 @@
 plugins {
-    alias(libs.plugins.androidLibrary)
-    alias(libs.plugins.jetbrains.kotlin)
-    alias(libs.plugins.kotlin.ksp)
+    alias(libs.plugins.gamedeals.android.library)
+    alias(libs.plugins.gamedeals.android.ksp)
     alias(libs.plugins.kotlinx.serialization)
 }
 
 android {
     namespace = "pm.bam.gamedeals.testing"
-    compileSdk = 36
 
     defaultConfig {
-        minSdk = 26
-
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }
 
     buildFeatures {
-        buildConfig = true // Enable by adding below line for a module that needs it
-    }
-
-    buildTypes {
-        release {
-            isMinifyEnabled = false
-            proguardFiles(getDefaultProguardFile("proguard-android-optimize.txt"))
-        }
-    }
-    compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_21
-        targetCompatibility = JavaVersion.VERSION_21
-    }
-    kotlin {
-        jvmToolchain(21)
-    }
-    packaging {
-        resources {
-            excludes += "/META-INF/LICENSE.md"
-            excludes += "/META-INF/LICENSE-notice.md"
-            excludes += "/META-INF/{AL2.0,LGPL2.1}"
-
-            // Temporary fix for OSGi issue org.jspecify:jspecify:1.0.0 and com.squareup.okhttp3:logging-interceptor:5.2.1
-            excludes += "META-INF/versions/9/OSGI-INF/MANIFEST.MF"
-        }
-    }
-    tasks.withType<Test> {
-        jvmArgs = listOf("-XX:+EnableDynamicAgentLoading")
+        buildConfig = true
     }
 }
 
 dependencies {
-
     implementation(project(":logging"))
     implementation(project(":common"))
 


### PR DESCRIPTION
## Summary

Closes #22.

Adds a Now-in-Android-style `build-logic/` included build with five precompiled convention plugins, then migrates every module's `build.gradle.kts` onto them. The 100+ lines of `compileSdk = 36` / `minSdk = 26` / JDK 21 / packaging-excludes / OSGi-workaround / Compose / Hilt-via-KSP boilerplate that was repeated across ~17 modules is now in one place.

### Convention plugins introduced

| Plugin ID | Applies |
|---|---|
| `pm.bam.gamedeals.android.library` | `com.android.library` + `org.jetbrains.kotlin.android` + the shared `compileSdk` / `minSdk` / JDK 21 / packaging excludes / `-XX:+EnableDynamicAgentLoading` test arg |
| `pm.bam.gamedeals.android.library.compose` | `org.jetbrains.kotlin.plugin.compose` + `buildFeatures.compose = true` |
| `pm.bam.gamedeals.android.ksp` | `com.google.devtools.ksp` only — deliberately not the Hilt Gradle plugin (preserves the pre-refactor boundary where only `:base` and `:app` had it) |
| `pm.bam.gamedeals.android.feature` | Composes the three above, adds `AndroidJUnitRunner` + emulator-control test option, and pulls in the universal Hilt + Compose + Paging + Coil + test stack shared by every core feature module |
| `pm.bam.gamedeals.android.application` | `com.android.application` + Kotlin Android + Compose Compiler + KSP, with the same shared library defaults |

The plugin classpath deps and convention-plugin IDs are registered in `gradle/libs.versions.toml`. `settings.gradle.kts` wires the build via `pluginManagement { includeBuild("build-logic") }`.

### Acceptance criteria

- [x] **Six `feature/*/build.gradle.kts` under 25 lines each.** Before / after for the six core feature modules:
  - `feature/home`: 110 → 22 lines
  - `feature/deal`: 98 → 18 lines
  - `feature/game`: 112 → 24 lines
  - `feature/giveaways`: 97 → 17 lines
  - `feature/search`: 96 → 17 lines
  - `feature/store`: 97 → 17 lines
  - (`feature/webview` stays at 37 lines on the simpler library + library.compose conventions — it has no Hilt, no Paging, no Coil, so the feature convention would force unused deps onto it.)
- [x] **No `kotlinCompilerExtensionVersion = "1.5.11"` literal anywhere.** `rg 1\.5\.11` returns only the lessons workspace report. The Compose Compiler Gradle plugin under Kotlin 2.x doesn't read it.
- [x] **`./gradlew build` / `./gradlew test` succeed clean.** Verified locally with JDK 21 (Android Studio's bundled JBR), and `./gradlew assembleDebug test` is green for every module.

### Modules migrated

Convention adopted: `:base`, `:common`, `:common:ui`, `:domain`, `:logging`, `:remote`, `:remote:cheapshark`, `:remote:gamerpower`, `:testing`, `:feature:home`, `:feature:deal`, `:feature:game`, `:feature:giveaways`, `:feature:search`, `:feature:store`, `:feature:webview`, `:app`.

No modules stayed on plain `build.gradle.kts`.

### Constraints honoured

- **CI JDK matches `targetCompatibility`.** Convention plugins centralise `compileOptions.sourceCompatibility = VERSION_21`, `targetCompatibility = VERSION_21`, and `kotlin { jvmToolchain(21) }`. `.github/workflows/android.yml` already pins `actions/setup-java@v4` to `java-version: '21'` so `:app:hiltJavaCompileDebug` won't see `error: invalid source release: 21` (L-2026-04-30-02). No workflow changes were needed.
- **No Robolectric.** Test conventions are JVM-only; no `org.robolectric:robolectric` is introduced anywhere (L-2026-05-01-02).
- **Purely structural.** No version bumps. AGP, Kotlin, Compose, Hilt, Coil, Paging, KSP, Room — all unchanged.
- **No auto-added module-specific deps.** The feature convention only adds deps that *every* core feature module already had; `:domain`'s Room compiler, `:remote*`'s Retrofit/OkHttp/Sandwich stack, `:base`'s Hilt Gradle plugin, etc. all stay in their respective modules.

## Test plan

- [x] `./gradlew assembleDebug` — green
- [x] `./gradlew test` — green
- [x] `./gradlew :app:assembleDebug` — green (verifies `hiltJavaCompileDebug` runs cleanly under the JDK 21 runner)
- [x] No occurrences of `kotlinCompilerExtensionVersion` in module `build.gradle.kts` files
- [ ] CI green (will be verified on this PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)