### PR TITLE
chore: drop lesson-id reference from CachedResourceTest doc

### DIFF
--- a/domain/src/test/java/pm/bam/gamedeals/domain/repositories/cache/CachedResourceTest.kt
+++ b/domain/src/test/java/pm/bam/gamedeals/domain/repositories/cache/CachedResourceTest.kt
@@ -12,8 +12,7 @@ import pm.bam.gamedeals.common.time.Clock
  * refresh and a fresh entry does not, without touching Room or any Android API.
  *
  * Picks a JVM unit test (over `androidTest` + in-memory Room) on purpose: [CachedResource] is
- * Flow-/Room-free, so a JVM test is faster, deterministic, and matches the project's policy of
- * not introducing Robolectric to drive deterministic-time tests (see L-2026-05-01-02).
+ * Flow-/Room-free, so a JVM test is faster, deterministic, and avoids pulling in Robolectric.
  */
 class CachedResourceTest {
 


### PR DESCRIPTION
## Summary
- Removes a parenthetical reference to an internal `.claude/lessons.md` ID (`L-2026-05-01-02`) that leaked into the KDoc of `CachedResourceTest`.
- Sibling cleanup to the same scrub already applied to `build-logic/` in PR #52 — keeps lesson IDs out of committed source.
- The surrounding sentence still explains the design choice ("avoids pulling in Robolectric"), so no rationale is lost.

## Test plan
- [ ] Build passes (`:domain:test`)
- [ ] No remaining `L-20\d{2}-\d{2}-\d{2}` or `lessons.md` references in `domain/`, `common/`, `app/`, `feature/*`, `build-logic/`