### PR TITLE
fix(#43): reset WebView loading state on recreation

### DIFF
--- a/feature/webview/src/main/java/pm/bam/gamedeals/feature/webview/ui/WebView.kt
+++ b/feature/webview/src/main/java/pm/bam/gamedeals/feature/webview/ui/WebView.kt
@@ -22,7 +22,7 @@ import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalUriHandler
@@ -43,7 +43,7 @@ internal fun WebView(
     url: String,
     onBack: () -> Unit
 ) {
-    var loading by rememberSaveable { mutableStateOf(true) }
+    var loading by remember { mutableStateOf(true) }
     val uriHandler = LocalUriHandler.current
 
     GameDealsTheme {


### PR DESCRIPTION
Closes #43.

`loading` is a transient WebViewClient signal — saving it across process
death restores `loading=true` while the WebView is freshly created and
idle, leaving the progress indicator stuck until the next page event.

Switched `rememberSaveable` to `remember` so the signal resets on
recomposition reattach.

🤖 Generated with [Claude Code](https://claude.com/claude-code)