### PR TITLE
fix(#46): let Paging LoadState surface deals errors

### DIFF
--- a/feature/store/src/main/java/pm/bam/gamedeals/feature/store/ui/StoreViewModel.kt
+++ b/feature/store/src/main/java/pm/bam/gamedeals/feature/store/ui/StoreViewModel.kt
@@ -69,7 +69,9 @@ internal class StoreViewModel @Inject constructor(
         // cachedIn() shares the paging state across multiple consumers of posts,
         // e.g. different generations of UI across rotation config change
         .cachedIn(viewModelScope)
-        .catch { logger.fatalThrowable(it) }
+        // No .catch here: Paging surfaces load errors via LoadState.Error so the UI can
+        // recover via retry(). A .catch after .cachedIn would swallow construction-time
+        // exceptions and leave LazyPagingItems stuck on the last-cached PagingData.
         .logFlow(logger)
 
     fun loadDealDetails(dealId: String, dealStoreId: Int, dealTitle: String, dealPriceDenominated: String) {


### PR DESCRIPTION
Closes #46.

The `.catch` on the `deals` Flow (after `.cachedIn`) was swallowing
construction-time exceptions and leaving the LazyPagingItems stuck on
the last-cached PagingData with no recovery path. Paging's LoadState
machinery already exposes errors to the UI, so the `.catch` is removed
and errors will surface through the existing LoadState handling.

Other `.catch` blocks in this ViewModel (non-Paging Flows) are
preserved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)