### PR TITLE
fix(#48): memoize fullscreenSemiTransparentBackground color

### DIFF
--- a/common/ui/src/main/java/pm/bam/gamedeals/common/ui/theme/Theme.kt
+++ b/common/ui/src/main/java/pm/bam/gamedeals/common/ui/theme/Theme.kt
@@ -12,6 +12,7 @@ import androidx.compose.material3.lightColorScheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.SideEffect
+import androidx.compose.runtime.remember
 import androidx.compose.runtime.staticCompositionLocalOf
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.toArgb
@@ -287,12 +288,12 @@ fun GameDealsTheme(
 }
 
 @Composable
-fun ColorScheme.fullscreenSemiTransparentBackground() =
-    if (isSystemInDarkTheme()) {
-        Color(0x8047464F)
-    } else {
-        Color(0x6547464F)
+fun ColorScheme.fullscreenSemiTransparentBackground(): Color {
+    val isDark = isSystemInDarkTheme()
+    return remember(isDark) {
+        if (isDark) Color(0x8047464F) else Color(0x6547464F)
     }
+}
 
 
 /**


### PR DESCRIPTION
Closes #48.

The `fullscreenSemiTransparentBackground` composable allocated a new
`Color` on every recomposition. Wrapped the allocation in
`remember(isSystemInDarkTheme())` so the color is memoized while the
dark/light theme is stable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)