### PR TITLE
fix(#47): drop Dispatchers.Default override on Coil ImageLoader

### DIFF
--- a/app/src/main/java/pm/bam/gamedeals/di/AppModule.kt
+++ b/app/src/main/java/pm/bam/gamedeals/di/AppModule.kt
@@ -11,7 +11,6 @@ import dagger.Provides
 import dagger.hilt.InstallIn
 import dagger.hilt.android.qualifiers.ApplicationContext
 import dagger.hilt.components.SingletonComponent
-import kotlinx.coroutines.Dispatchers
 import pm.bam.gamedeals.common.time.Clock
 import pm.bam.gamedeals.logging.Logger
 import pm.bam.gamedeals.logging.toLogLevel
@@ -53,7 +52,6 @@ class AppModule {
         @Coil coilLogger: coil.util.Logger
     ): ImageLoader = ImageLoader.Builder(appContext)
         .crossfade(true)
-        .dispatcher(Dispatchers.Default)
         .logger(coilLogger)
         .build()
 


### PR DESCRIPTION
Closes #47.

Coil's image fetching and decoding is I/O-bound. Routing it through
`Dispatchers.Default` (CPU-sized pool) can starve real CPU work and
reduce image-load concurrency. Coil's own default is `Dispatchers.IO`,
so the explicit override is dropped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)