### PR TITLE
fix(#44): key window theming on LaunchedEffect

### DIFF
--- a/common/ui/src/main/java/pm/bam/gamedeals/common/ui/theme/Theme.kt
+++ b/common/ui/src/main/java/pm/bam/gamedeals/common/ui/theme/Theme.kt
@@ -11,7 +11,7 @@ import androidx.compose.material3.dynamicLightColorScheme
 import androidx.compose.material3.lightColorScheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
-import androidx.compose.runtime.SideEffect
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.staticCompositionLocalOf
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.toArgb
@@ -268,7 +268,7 @@ fun GameDealsTheme(
     }
     val view = LocalView.current
     if (!view.isInEditMode) {
-        SideEffect {
+        LaunchedEffect(colorScheme.primary, darkTheme) {
             val window = (view.context as Activity).window
             window.statusBarColor = colorScheme.primary.toArgb()
             WindowCompat.getInsetsController(window, view).isAppearanceLightStatusBars = darkTheme


### PR DESCRIPTION
Closes #44.

The previous `SideEffect` ran on every successful recomposition,
mutating Activity Window's `statusBarColor` and appearance flag with
no key. Replaced with `LaunchedEffect(colorScheme.primary, darkTheme)`
so the window state is only re-applied when the inputs actually change.

The deeper concern (nested `GameDealsTheme` wrappers double-applying
window state from each screen) is out of scope for this issue and
left for future cleanup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)