### PR TITLE
fix(#45): use delay for *DelayAtLeast virtual-time padding

### DIFF
--- a/common/build.gradle.kts
+++ b/common/build.gradle.kts
@@ -26,6 +26,7 @@ dependencies {
     implementation(project(":logging"))
 
     testImplementation(libs.junit)
+    testImplementation(libs.coroutines.testing)
 
     androidTestImplementation(libs.androidx.junit)
     androidTestImplementation(libs.androidx.espresso.core)

--- a/common/src/main/java/pm/bam/gamedeals/common/FlowExtensions.kt
+++ b/common/src/main/java/pm/bam/gamedeals/common/FlowExtensions.kt
@@ -1,8 +1,10 @@
 package pm.bam.gamedeals.common
 
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.async
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.FlowCollector
 import kotlinx.coroutines.flow.catch
@@ -66,26 +68,24 @@ inline fun <T> Flow<T>.onCompletionFailure(crossinline failureAction: suspend Fl
 fun <T> Flow<T>.delayOnStart(delayMillis: Long): Flow<T> = onStart { delay(delayMillis) }
 
 /**
- * Returns a flow containing the results of applying the given [transform] function to each value of the original flow
+ * Returns a flow containing the results of applying the given [transformFunction] to each value of the original flow
  * only after given [delayMillis] has passed, either because the transformation took more or equal amount of time as the [delayMillis],
  * or because the suspend function was delayed for the remaining time.
+ *
+ * Implementation runs the transformation and the [delay] concurrently inside a [coroutineScope]
+ * so the elapsed time is measured by the coroutine's own clock. This makes the operator behave
+ * identically in production and under `runTest` with a `TestDispatcher`'s virtual time, instead
+ * of relying on `System.currentTimeMillis()` (which ignores the test's virtual clock).
  */
 fun <T, R> Flow<T>.mapDelayAtLeast(delayMillis: Long, transformFunction: suspend (value: T) -> R): Flow<R> =
     transform { value ->
-        val timeBeforeTransformation = System.currentTimeMillis()
-        val transformedTransformation = transformFunction(value)
-        val timeAfterTransformation = System.currentTimeMillis()
-
-        val transformationDuration = timeAfterTransformation - timeBeforeTransformation
-
-        val transformationShorterThanDelay = delayMillis > transformationDuration
-
-        if (transformationShorterThanDelay) {
-            val remainingDelay = delayMillis - transformationDuration
-            delay(remainingDelay)
+        coroutineScope {
+            val deferred = async { transformFunction(value) }
+            val pad = launch { delay(delayMillis) }
+            val result = deferred.await()
+            pad.join()
+            emit(result)
         }
-
-        return@transform emit(transformedTransformation)
     }
 
 
@@ -105,53 +105,39 @@ suspend inline fun <T> withMinimumDuration(delayMillis: Long, crossinline block:
 
 
 /**
- * Returns a flow containing the results of applying the given [transformLatest] function to each value of the original flow
+ * Returns a flow containing the results of applying the given [transformFunction] to each value of the original flow
  * only after given [delayMillis] has passed, either because the transformation took more or equal amount of time as the [delayMillis],
  * or because the suspend function was delayed for the remaining time.
+ *
+ * Like [mapDelayAtLeast] but using `transformLatest` so a new upstream value cancels any in-flight
+ * transformation. Time is measured via [delay] inside [coroutineScope] for virtual-time correctness
+ * under `runTest`.
  */
 @OptIn(ExperimentalCoroutinesApi::class)
 inline fun <T, R> Flow<T>.flatMapLatestDelayAtLeast(delayMillis: Long, crossinline transformFunction: suspend (value: T) -> R): Flow<R> =
     transformLatest { value ->
-
-        val timeBeforeTransformation = System.currentTimeMillis()
-        val transformedTransformation = transformFunction(value)
-        val timeAfterTransformation = System.currentTimeMillis()
-
-        val transformationDuration = timeAfterTransformation - timeBeforeTransformation
-
-        val transformationShorterThanDelay = delayMillis > transformationDuration
-
-        if (transformationShorterThanDelay) {
-            val remainingDelay = delayMillis - transformationDuration
-            delay(remainingDelay)
+        coroutineScope {
+            val deferred = async { transformFunction(value) }
+            val pad = launch { delay(delayMillis) }
+            val result = deferred.await()
+            pad.join()
+            emit(result)
         }
-
-        return@transformLatest emit(transformedTransformation)
     }
 
 
 /**
- * Returns a flow containing the results of applying the given [transformLatest] function to each value of the original flow
- * only after given [delayMillis] has passed, either because the transformation took more or equal amount of time as the [delayMillis],
- * or because the suspend function was delayed for the remaining time.
+ * Returns a flow that emits each value of the original flow only after given [delayMillis] has
+ * passed since that value arrived. Uses `transformLatest`, so a new upstream value cancels any
+ * pending pad before it emits.
+ *
+ * Time is measured via [delay] for virtual-time correctness under `runTest`.
  */
 @OptIn(ExperimentalCoroutinesApi::class)
 fun <T> Flow<T>.latestDelayAtLeast(delayMillis: Long): Flow<T> =
     transformLatest { value ->
-
-        val timeBeforeTransformation = System.currentTimeMillis()
-        val timeAfterTransformation = System.currentTimeMillis()
-
-        val transformationDuration = timeAfterTransformation - timeBeforeTransformation
-
-        val transformationShorterThanDelay = delayMillis > transformationDuration
-
-        if (transformationShorterThanDelay) {
-            val remainingDelay = delayMillis - transformationDuration
-            delay(remainingDelay)
-        }
-
-        return@transformLatest emit(value)
+        delay(delayMillis)
+        emit(value)
     }
 
 /**

--- a/common/src/test/java/pm/bam/gamedeals/common/FlowExtensionsTest.kt
+++ b/common/src/test/java/pm/bam/gamedeals/common/FlowExtensionsTest.kt
@@ -1,0 +1,117 @@
+package pm.bam.gamedeals.common
+
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.flow.toList
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+/**
+ * Verifies the virtual-time correctness of the `*DelayAtLeast` Flow operators.
+ *
+ * The previous implementation relied on `System.testScheduler.currentTimeMillis()` to measure
+ * the duration of the inner transformation, which does not honour the test
+ * dispatcher's virtual clock. Under `runTest` the measured duration was always
+ * ~0, so the operator always padded to the full `delayMillis`.
+ *
+ * The new implementation uses only `delay`, so behaviour matches between
+ * production wall-clock and virtual time: the operator emits after at least
+ * `delayMillis`, or after the inner transformation completes, whichever is later.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class FlowExtensionsTest {
+
+    @Test
+    fun `mapDelayAtLeast pads to delayMillis when transform is instant`() = runTest {
+        val start = testScheduler.currentTime
+        val results = flowOf(1)
+            .mapDelayAtLeast(DELAY_MILLIS) { it * 2 }
+            .toList()
+        val elapsed = testScheduler.currentTime - start
+
+        assertEquals(listOf(2), results)
+        assertEquals(DELAY_MILLIS, elapsed)
+    }
+
+    @Test
+    fun `mapDelayAtLeast does not pad when transform takes longer than delayMillis`() = runTest {
+        val start = testScheduler.currentTime
+        val results = flowOf(1)
+            .mapDelayAtLeast(DELAY_MILLIS) { value ->
+                delay(LONG_WORK_MILLIS)
+                value * 2
+            }
+            .toList()
+        val elapsed = testScheduler.currentTime - start
+
+        assertEquals(listOf(2), results)
+        assertEquals(LONG_WORK_MILLIS, elapsed)
+    }
+
+    @Test
+    fun `flatMapLatestDelayAtLeast pads to delayMillis when transform is instant`() = runTest {
+        val start = testScheduler.currentTime
+        val results = flowOf(1)
+            .flatMapLatestDelayAtLeast(DELAY_MILLIS) { it * 2 }
+            .toList()
+        val elapsed = testScheduler.currentTime - start
+
+        assertEquals(listOf(2), results)
+        assertEquals(DELAY_MILLIS, elapsed)
+    }
+
+    @Test
+    fun `flatMapLatestDelayAtLeast does not pad when transform takes longer than delayMillis`() = runTest {
+        val start = testScheduler.currentTime
+        val results = flowOf(1)
+            .flatMapLatestDelayAtLeast(DELAY_MILLIS) { value ->
+                delay(LONG_WORK_MILLIS)
+                value * 2
+            }
+            .toList()
+        val elapsed = testScheduler.currentTime - start
+
+        assertEquals(listOf(2), results)
+        assertEquals(LONG_WORK_MILLIS, elapsed)
+    }
+
+    @Test
+    fun `latestDelayAtLeast emits after delayMillis virtual time`() = runTest {
+        val start = testScheduler.currentTime
+        val results = flowOf(42)
+            .latestDelayAtLeast(DELAY_MILLIS)
+            .toList()
+        val elapsed = testScheduler.currentTime - start
+
+        assertEquals(listOf(42), results)
+        assertEquals(DELAY_MILLIS, elapsed)
+    }
+
+    @Test
+    fun `latestDelayAtLeast cancels pending pad when a new value arrives`() = runTest {
+        // Emits 1 immediately, then 2 after `delayMillis * 2`. Because
+        // `latestDelayAtLeast` uses `transformLatest`, the in-flight pad for
+        // value 1 should be cancelled when value 2 arrives, so only value 2 is
+        // emitted (after its own pad).
+        val start = testScheduler.currentTime
+        val results = kotlinx.coroutines.flow.flow {
+            emit(1)
+            delay(DELAY_MILLIS / 2)
+            emit(2)
+        }
+            .latestDelayAtLeast(DELAY_MILLIS)
+            .toList()
+        val elapsed = testScheduler.currentTime - start
+
+        assertEquals(listOf(2), results)
+        // Value 2 arrives at DELAY_MILLIS / 2, then pads for DELAY_MILLIS.
+        assertEquals(DELAY_MILLIS / 2 + DELAY_MILLIS, elapsed)
+    }
+
+    private companion object {
+        const val DELAY_MILLIS = 1_000L
+        const val LONG_WORK_MILLIS = 3_000L
+    }
+}


### PR DESCRIPTION
Closes #45.

The three `*DelayAtLeast` operators measured transform duration with
`System.currentTimeMillis()` and then `delay(remaining)`. Under
`runTest` with a `TestDispatcher`, `delay` honors virtual time but
`System.currentTimeMillis()` does not, so the measured duration was
~0 and the operator always padded to the full `delayMillis`.

Refactored all three operators to launch the inner work and a `delay`
in parallel via `coroutineScope { async; launch; await; join }`. This
keeps the "at least delayMillis" semantics in production while being
fully virtual-time aware in tests.

Added `FlowExtensionsTest` covering all three operators with
`runTest` to assert virtual-time behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)