### PR TITLE
fix(#31): rethrow CancellationException in DealsMediator.load

### DIFF
--- a/domain/src/main/java/pm/bam/gamedeals/domain/repositories/deals/paging/DealsMediator.kt
+++ b/domain/src/main/java/pm/bam/gamedeals/domain/repositories/deals/paging/DealsMediator.kt
@@ -8,6 +8,7 @@ import androidx.paging.LoadType.REFRESH
 import androidx.paging.PagingState
 import androidx.paging.RemoteMediator
 import androidx.room.withTransaction
+import kotlinx.coroutines.CancellationException
 import kotlinx.serialization.ExperimentalSerializationApi
 import pm.bam.gamedeals.domain.db.DomainDatabase
 import pm.bam.gamedeals.domain.models.Deal
@@ -72,6 +73,12 @@ internal class DealsMediator(
             }
 
             return MediatorResult.Success(endOfPaginationReached = deals.isEmpty())
+        } catch (e: CancellationException) {
+            // Honour structured concurrency: never swallow cancellation. Paging /
+            // viewModelScope cancels mid-load on normal navigation, and reporting
+            // that as `MediatorResult.Error` surfaces a fake load failure to the UI
+            // and a fatal log entry to Crashlytics.
+            throw e
         } catch (e: Exception) {
             fatal(logger, e)
             return MediatorResult.Error(e)

--- a/domain/src/test/java/pm/bam/gamedeals/domain/repositories/deals/paging/DealsMediatorTest.kt
+++ b/domain/src/test/java/pm/bam/gamedeals/domain/repositories/deals/paging/DealsMediatorTest.kt
@@ -15,10 +15,13 @@ import io.mockk.mockk
 import io.mockk.mockkStatic
 import io.mockk.runs
 import io.mockk.slot
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
+import org.junit.Assert.assertSame
 import org.junit.Assert.assertTrue
+import org.junit.Assert.fail
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
@@ -135,6 +138,30 @@ internal class DealsMediatorTest {
 
         coVerify(exactly = 0) { pagingDao.insert(any()) }
         coVerify(exactly = 0) { dealsDao.addDeals(any()) }
+    }
+
+
+    @Test
+    fun `APPEND rethrows CancellationException instead of returning Error`() = runTest {
+        val page = 0
+        val dealPage = DealPage(defaultStoreId, page)
+        val cancellation = CancellationException("scope cancelled")
+
+        coEvery { pagingDao.getStorePage(defaultStoreId) } returns dealPage
+        coEvery { cheapsharkSource.fetchDealsForStore(query = any()) } throws cancellation
+
+
+        try {
+            mediator.load(LoadType.APPEND, state)
+            fail("Expected CancellationException to propagate")
+        } catch (e: CancellationException) {
+            assertSame(cancellation, e)
+        }
+
+        coVerify(exactly = 1) { pagingDao.getStorePage(defaultStoreId) }
+        coVerify(exactly = 1) { cheapsharkSource.fetchDealsForStore(query = any()) }
+        coVerify(exactly = 0) { domainDatabase.withTransaction(any()) }
+        coVerify(exactly = 0) { logger.fatalThrowable(any(), any()) }
     }
 
 


### PR DESCRIPTION
Closes #31.

## Summary
`DealsMediator.load` wrapped its body in `try { ... } catch (e: Exception) { ... }`, which also caught `CancellationException` (it inherits from `RuntimeException`/`Exception` on Kotlin/JVM). On normal navigation away from `StoreScreen`, Paging/`viewModelScope` cancellation was therefore:

- logged via `fatal(logger, e)` (Crashlytics noise),
- returned as `MediatorResult.Error`, surfacing a fake `LoadState.Error` (error banner / retry) for what was a normal cancel,
- swallowing the cancellation and breaking structured concurrency.

## Fix
Add a dedicated `catch (e: CancellationException) { throw e }` block before the generic `Exception` handler so cancellation propagates upward as the coroutines machinery expects. Generic exceptions still get the fatal log + `MediatorResult.Error` path.

## Tests
Added `APPEND rethrows CancellationException instead of returning Error` to `DealsMediatorTest`, which:
- throws a `CancellationException` from `cheapsharkSource.fetchDealsForStore`,
- asserts the same exception propagates out of `load`,
- verifies no DB transaction runs and the logger's `fatalThrowable` is never called.

`./gradlew :domain:test` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)