### PR TITLE
fix(#41): use LocalActivity in GameDealsTheme to avoid ClassCastException

### DIFF
--- a/common/ui/build.gradle.kts
+++ b/common/ui/build.gradle.kts
@@ -15,6 +15,7 @@ dependencies {
     implementation(libs.androidx.ktx)
     implementation(libs.androidx.appcompat)
     implementation(libs.material)
+    implementation(libs.androidx.compose.activity)
     implementation(libs.androidx.compose.navigation)
     implementation(libs.androidx.compose.runtime)
 

--- a/common/ui/src/main/java/pm/bam/gamedeals/common/ui/theme/Theme.kt
+++ b/common/ui/src/main/java/pm/bam/gamedeals/common/ui/theme/Theme.kt
@@ -1,7 +1,7 @@
 package pm.bam.gamedeals.common.ui.theme
 
-import android.app.Activity
 import android.os.Build
+import androidx.activity.compose.LocalActivity
 import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.material3.ColorScheme
 import androidx.compose.material3.MaterialTheme
@@ -12,7 +12,6 @@ import androidx.compose.material3.lightColorScheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.SideEffect
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.staticCompositionLocalOf
 import androidx.compose.ui.graphics.Color
@@ -269,9 +268,13 @@ fun GameDealsTheme(
         else -> lightScheme
     }
     val view = LocalView.current
-    if (!view.isInEditMode) {
+    val activity = LocalActivity.current
+    // `activity` is null in non-Activity hosts such as @Preview renders on device,
+    // ComposeViews used in service notifications, or dialogs hosted on Application
+    // context. Skip status-bar styling rather than crashing with ClassCastException.
+    if (!view.isInEditMode && activity != null) {
         LaunchedEffect(colorScheme.primary, darkTheme) {
-            val window = (view.context as Activity).window
+            val window = activity.window
             window.statusBarColor = colorScheme.primary.toArgb()
             WindowCompat.getInsetsController(window, view).isAppearanceLightStatusBars = darkTheme
         }


### PR DESCRIPTION
Closes #41.

## Summary
- Replace the unsafe `(view.context as Activity)` cast inside `GameDealsTheme`'s `LaunchedEffect` with `LocalActivity.current` (from `androidx.activity.compose`), and only apply status-bar styling when `activity != null`.
- The old cast assumed the composition was always hosted by an `Activity`, which crashes with `ClassCastException` for non-Activity hosts: `@Preview` renders on device, `ComposeView`s in service notifications, dialogs hosted on Application context, etc. The codebase already has several `@Preview`s wrapped in `GameDealsTheme` (e.g. `WebView.kt`, DealBottomSheet previews) that would trip this when previewed on a real device.
- Adds the `androidx.activity:activity-compose` (1.11.0, already in the version catalog) dependency to `:common:ui` so `LocalActivity` resolves.

The recently-merged `LaunchedEffect` block from #44 is preserved; only the `Activity` lookup inside it changes.

## Test plan
- [x] `./gradlew :common:ui:test` (the module currently has no JVM unit tests, so this is `NO-SOURCE`; the change was exercised through `:common:ui:compileDebugKotlin` / `compileReleaseKotlin`, both of which compile cleanly).
- [ ] Manual: run the app and confirm status bar still adopts theme colors on `MainActivity`.
- [ ] Manual: render a `@Preview` that wraps `GameDealsTheme` on a connected device and confirm it no longer crashes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)