### PR TITLE
fix(#42): make Storage suspend and run prefs I/O off main thread

### DIFF
--- a/app/src/main/java/pm/bam/gamedeals/GameDealsApplication.kt
+++ b/app/src/main/java/pm/bam/gamedeals/GameDealsApplication.kt
@@ -18,11 +18,6 @@ class GameDealsApplication : Application(), ImageLoaderFactory {
         super.onCreate()
         if (isDebuggable()) {
             // Surface accidental disk / network I/O on the main thread during development.
-            // Logged (not crashed) so dev builds remain usable while regressions are visible
-            // in Logcat — production code paths are untouched. Detection is gated on the
-            // FLAG_DEBUGGABLE manifest bit (set automatically for the `debug` build type)
-            // rather than BuildConfig.DEBUG to avoid having to opt the app module into
-            // buildFeatures.buildConfig generation.
             StrictMode.setThreadPolicy(
                 StrictMode.ThreadPolicy.Builder()
                     .detectAll()

--- a/app/src/main/java/pm/bam/gamedeals/GameDealsApplication.kt
+++ b/app/src/main/java/pm/bam/gamedeals/GameDealsApplication.kt
@@ -1,6 +1,8 @@
 package pm.bam.gamedeals
 
 import android.app.Application
+import android.content.pm.ApplicationInfo
+import android.os.StrictMode
 import coil.ImageLoader
 import coil.ImageLoaderFactory
 import dagger.hilt.android.HiltAndroidApp
@@ -12,5 +14,26 @@ class GameDealsApplication : Application(), ImageLoaderFactory {
     @Inject
     lateinit var imageLoader: ImageLoader
 
+    override fun onCreate() {
+        super.onCreate()
+        if (isDebuggable()) {
+            // Surface accidental disk / network I/O on the main thread during development.
+            // Logged (not crashed) so dev builds remain usable while regressions are visible
+            // in Logcat — production code paths are untouched. Detection is gated on the
+            // FLAG_DEBUGGABLE manifest bit (set automatically for the `debug` build type)
+            // rather than BuildConfig.DEBUG to avoid having to opt the app module into
+            // buildFeatures.buildConfig generation.
+            StrictMode.setThreadPolicy(
+                StrictMode.ThreadPolicy.Builder()
+                    .detectAll()
+                    .penaltyLog()
+                    .build()
+            )
+        }
+    }
+
     override fun newImageLoader(): ImageLoader = imageLoader
+
+    private fun isDebuggable(): Boolean =
+        (applicationInfo.flags and ApplicationInfo.FLAG_DEBUGGABLE) != 0
 }

--- a/common/build.gradle.kts
+++ b/common/build.gradle.kts
@@ -28,10 +28,7 @@ dependencies {
     implementation(project(":logging"))
 
     testImplementation(libs.junit)
-<<<<<<< wave/2026-05-01-bug-hunt/issue-42-storage-suspend
     testImplementation(libs.mockk)
-=======
->>>>>>> dev
     testImplementation(libs.coroutines.testing)
 
     androidTestImplementation(libs.androidx.junit)

--- a/common/build.gradle.kts
+++ b/common/build.gradle.kts
@@ -23,9 +23,13 @@ dependencies {
     ksp(libs.hilt.compiler)
     ksp(libs.hilt.androidx.compiler)
 
+    implementation(libs.coroutines)
+
     implementation(project(":logging"))
 
     testImplementation(libs.junit)
+    testImplementation(libs.mockk)
+    testImplementation(libs.coroutines.testing)
 
     androidTestImplementation(libs.androidx.junit)
     androidTestImplementation(libs.androidx.espresso.core)

--- a/common/src/main/java/pm/bam/gamedeals/common/storage/SettingStorage.kt
+++ b/common/src/main/java/pm/bam/gamedeals/common/storage/SettingStorage.kt
@@ -1,6 +1,9 @@
 package pm.bam.gamedeals.common.storage
 
 import android.content.SharedPreferences
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
 import kotlinx.serialization.DeserializationStrategy
 import kotlinx.serialization.SerializationStrategy
 import pm.bam.gamedeals.common.di.Settings
@@ -12,25 +15,36 @@ import javax.inject.Inject
 internal class SettingStorage @Inject constructor(
     private val serializer: Serializer,
     @Settings val sharedPreferences: SharedPreferences,
+    private val ioDispatcher: CoroutineDispatcher = Dispatchers.IO,
 ) : Storage {
 
-    override fun <T : Any> get(storageKey: String, deserializationStrategy: DeserializationStrategy<T>, defaultValue: T?): T =
+    override suspend fun <T : Any> get(storageKey: String, deserializationStrategy: DeserializationStrategy<T>, defaultValue: T?): T =
         getNullable(storageKey, deserializationStrategy, defaultValue) ?: throw DataNotFoundException(storageKey)
 
-    override fun <T : Any> getNullable(storageKey: String, deserializationStrategy: DeserializationStrategy<T>, defaultValue: T?): T? =
-        sharedPreferences.getString(storageKey, null)
-            ?.let { serializedData -> serializer.deserialize(serializedData, deserializationStrategy) }
-            .let { data -> data ?: defaultValue }
-
-    override fun <T : Any> save(storageKey: String, data: T, serializationStrategy: SerializationStrategy<T>, overwrite: Boolean): Boolean {
-        if (!overwrite && containsKey(storageKey)) {
-            throw DataExistsException(storageKey)
+    override suspend fun <T : Any> getNullable(storageKey: String, deserializationStrategy: DeserializationStrategy<T>, defaultValue: T?): T? =
+        withContext(ioDispatcher) {
+            sharedPreferences.getString(storageKey, null)
+                ?.let { serializedData -> serializer.deserialize(serializedData, deserializationStrategy) }
+                .let { data -> data ?: defaultValue }
         }
 
-        return sharedPreferences.edit().putString(storageKey, serializer.serialize(data, serializationStrategy)).commit()
+    override suspend fun <T : Any> save(storageKey: String, data: T, serializationStrategy: SerializationStrategy<T>, overwrite: Boolean): Boolean =
+        withContext(ioDispatcher) {
+            if (!overwrite && sharedPreferences.contains(storageKey)) {
+                throw DataExistsException(storageKey)
+            }
+
+            // commit() is intentionally retained over apply(): we are already off the main thread
+            // inside withContext(Dispatchers.IO), and callers that suspend on save() expect a
+            // truthful Boolean result reflecting whether the write actually succeeded.
+            sharedPreferences.edit().putString(storageKey, serializer.serialize(data, serializationStrategy)).commit()
+        }
+
+    override suspend fun containsKey(storageKey: String): Boolean = withContext(ioDispatcher) {
+        sharedPreferences.contains(storageKey)
     }
 
-    override fun containsKey(storageKey: String): Boolean = sharedPreferences.contains(storageKey)
-
-    override fun remove(storageKey: String): Boolean = sharedPreferences.edit().remove(storageKey).commit()
+    override suspend fun remove(storageKey: String): Boolean = withContext(ioDispatcher) {
+        sharedPreferences.edit().remove(storageKey).commit()
+    }
 }

--- a/common/src/main/java/pm/bam/gamedeals/common/storage/Storage.kt
+++ b/common/src/main/java/pm/bam/gamedeals/common/storage/Storage.kt
@@ -15,13 +15,13 @@ interface Storage {
      * @throws DataNotFoundException if no data found for given [storageKey] and no [defaultValue] is given.
      */
     @Throws(DataNotFoundException::class)
-    fun <T : Any> get(storageKey: String, deserializationStrategy: DeserializationStrategy<T>, defaultValue: T? = null): T
+    suspend fun <T : Any> get(storageKey: String, deserializationStrategy: DeserializationStrategy<T>, defaultValue: T? = null): T
 
     /**
      * Retrieves the data found at the given [storageKey] mapping, or the [defaultValue] if given.
      * Also deserializes to given type token for complex types such as as Lists, Sets or Maps.
      */
-    fun <T : Any> getNullable(storageKey: String, deserializationStrategy: DeserializationStrategy<T>, defaultValue: T? = null): T?
+    suspend fun <T : Any> getNullable(storageKey: String, deserializationStrategy: DeserializationStrategy<T>, defaultValue: T? = null): T?
 
     /**
      * Saves the data at the given [storageKey] mapping as a serialized string for complex types such as Lists, Sets or Maps,
@@ -30,15 +30,15 @@ interface Storage {
      * @throws DataExistsException if [overwrite] is true and data exists for the given [storageKey].
      */
     @Throws(DataExistsException::class)
-    fun <T : Any> save(storageKey: String, data: T, serializationStrategy: SerializationStrategy<T>, overwrite: Boolean = true): Boolean
+    suspend fun <T : Any> save(storageKey: String, data: T, serializationStrategy: SerializationStrategy<T>, overwrite: Boolean = true): Boolean
 
     /** Returns a boolean indicating whether the storage contains data for the given [storageKey]. */
-    fun containsKey(storageKey: String): Boolean
+    suspend fun containsKey(storageKey: String): Boolean
 
     /**
      * Removes any data found at the given [storageKey] mapping.
      *
      * @return True for remove data, False for any other scenario.
      */
-    fun remove(storageKey: String): Boolean
+    suspend fun remove(storageKey: String): Boolean
 }

--- a/common/src/test/java/pm/bam/gamedeals/common/storage/SettingStorageTest.kt
+++ b/common/src/test/java/pm/bam/gamedeals/common/storage/SettingStorageTest.kt
@@ -1,0 +1,128 @@
+package pm.bam.gamedeals.common.storage
+
+import android.content.SharedPreferences
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.runTest
+import kotlinx.serialization.DeserializationStrategy
+import kotlinx.serialization.SerializationStrategy
+import kotlinx.serialization.builtins.serializer
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertThrows
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import pm.bam.gamedeals.common.exceptions.DataExistsException
+import pm.bam.gamedeals.common.exceptions.DataNotFoundException
+import pm.bam.gamedeals.common.serializer.Serializer
+
+/**
+ * Boundary test for [SettingStorage]: verifies that the suspending API performs the expected
+ * SharedPreferences read / write side effects via a mocked editor, and that exception cases
+ * surface correctly.
+ *
+ * The implementation wraps every prefs call in `withContext(Dispatchers.IO)`; we substitute an
+ * [UnconfinedTestDispatcher] so the suspend functions execute synchronously inside `runTest`
+ * without relying on real I/O scheduling. No Robolectric / Android runtime needed.
+ */
+class SettingStorageTest {
+
+    private val key = "test-key"
+    private val stringStrategy: SerializationStrategy<String> = String.serializer()
+    private val deserStrategy: DeserializationStrategy<String> = String.serializer()
+
+    private val serializer: Serializer = mockk(relaxed = true)
+    private val sharedPreferences: SharedPreferences = mockk(relaxed = true)
+    private val editor: SharedPreferences.Editor = mockk(relaxed = true)
+    private val dispatcher = UnconfinedTestDispatcher()
+
+    private val storage = SettingStorage(serializer, sharedPreferences, dispatcher)
+
+    @Test
+    fun `getNullable - missing key returns default`() = runTest {
+        every { sharedPreferences.getString(key, null) } returns null
+
+        val result = storage.getNullable(key, deserStrategy, defaultValue = "fallback")
+
+        assertEquals("fallback", result)
+    }
+
+    @Test
+    fun `getNullable - missing key with no default returns null`() = runTest {
+        every { sharedPreferences.getString(key, null) } returns null
+
+        val result = storage.getNullable(key, deserStrategy)
+
+        assertNull(result)
+    }
+
+    @Test
+    fun `getNullable - present key deserializes via Serializer`() = runTest {
+        every { sharedPreferences.getString(key, null) } returns "serialized"
+        every { serializer.deserialize<String>("serialized", deserStrategy) } returns "decoded"
+
+        val result = storage.getNullable(key, deserStrategy)
+
+        assertEquals("decoded", result)
+    }
+
+    @Test
+    fun `get - missing key throws DataNotFoundException`() = runTest {
+        every { sharedPreferences.getString(key, null) } returns null
+
+        assertThrows(DataNotFoundException::class.java) {
+            kotlinx.coroutines.runBlocking { storage.get(key, deserStrategy) }
+        }
+    }
+
+    @Test
+    fun `save - overwrite true commits serialized value`() = runTest {
+        every { serializer.serialize("payload", stringStrategy) } returns "serialized-payload"
+        every { sharedPreferences.edit() } returns editor
+        every { editor.putString(key, "serialized-payload") } returns editor
+        every { editor.commit() } returns true
+
+        val result = storage.save(key, "payload", stringStrategy, overwrite = true)
+
+        assertTrue(result)
+        verify { editor.putString(key, "serialized-payload") }
+        verify { editor.commit() }
+    }
+
+    @Test
+    fun `save - overwrite false with existing key throws DataExistsException`() = runTest {
+        every { sharedPreferences.contains(key) } returns true
+
+        assertThrows(DataExistsException::class.java) {
+            kotlinx.coroutines.runBlocking {
+                storage.save(key, "payload", stringStrategy, overwrite = false)
+            }
+        }
+        // Implementation must not attempt any write when the key already exists.
+        verify(exactly = 0) { sharedPreferences.edit() }
+    }
+
+    @Test
+    fun `containsKey - delegates to SharedPreferences`() = runTest {
+        every { sharedPreferences.contains(key) } returns true
+
+        assertTrue(storage.containsKey(key))
+        verify { sharedPreferences.contains(key) }
+    }
+
+    @Test
+    fun `remove - commits editor remove and returns its result`() = runTest {
+        every { sharedPreferences.edit() } returns editor
+        every { editor.remove(key) } returns editor
+        every { editor.commit() } returns false
+
+        val result = storage.remove(key)
+
+        assertFalse(result)
+        verify { editor.remove(key) }
+        verify { editor.commit() }
+    }
+}


### PR DESCRIPTION
Closes #42.

## Summary
- Convert all five `Storage` interface methods to `suspend` functions and wrap `SettingStorage`'s SharedPreferences reads / writes in `withContext(Dispatchers.IO)`. No production caller exists today (verified via grep), so this is a forward-compatible API hardening before the first real consumer lands.
- `.commit()` is kept rather than swapped to `.apply()`. Justification: we are already off the main thread inside `withContext(Dispatchers.IO)`, so the synchronous-flush cost no longer risks an ANR, and callers that suspend on `save` / `remove` benefit from a truthful `Boolean` return reflecting whether the write actually succeeded.
- Enable `StrictMode.ThreadPolicy.detectAll().penaltyLog()` in `GameDealsApplication.onCreate` for debug builds. Detection is gated on `ApplicationInfo.FLAG_DEBUGGABLE` (set automatically for the `debug` build type) rather than `BuildConfig.DEBUG`, which avoids opting `:app` into `buildFeatures.buildConfig` generation just for one boolean.
- Add `SettingStorageTest` covering `get` / `getNullable` / `save` / `remove` / `containsKey` plus the `DataNotFoundException` / `DataExistsException` branches. This required adding `mockk` and `kotlinx-coroutines-test` to `:common`'s test configuration (precedented by issue #45).

## Test plan
- [x] `./gradlew :common:test` — 8 new tests, all green.
- [x] `./gradlew :app:assembleDebug` — clean build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)