### PR TITLE
fix(#34): load URL in factory and guard WebView.update against reloads

### DIFF
--- a/feature/webview/src/main/java/pm/bam/gamedeals/feature/webview/ui/WebView.kt
+++ b/feature/webview/src/main/java/pm/bam/gamedeals/feature/webview/ui/WebView.kt
@@ -78,12 +78,9 @@ internal fun WebView(
                     )
                 }
             ) { contentPadding: PaddingValues ->
-                // Track the last URL we loaded so `update` only reloads when the
-                // `url` argument actually changes. Without this guard, every parent
-                // recomposition (e.g. `loading` toggling) would call `loadUrl(url)`
-                // again and snap the WebView back to the original URL, breaking
-                // intra-WebView navigation. See issue #34.
+                // Track the last URL we loaded so `update` only reloads when the `url` argument actually changes.
                 var lastLoadedUrl by remember { mutableStateOf<String?>(null) }
+                
                 AndroidView(
                     modifier = Modifier.padding(contentPadding),
                     factory = { context ->

--- a/feature/webview/src/main/java/pm/bam/gamedeals/feature/webview/ui/WebView.kt
+++ b/feature/webview/src/main/java/pm/bam/gamedeals/feature/webview/ui/WebView.kt
@@ -78,6 +78,12 @@ internal fun WebView(
                     )
                 }
             ) { contentPadding: PaddingValues ->
+                // Track the last URL we loaded so `update` only reloads when the
+                // `url` argument actually changes. Without this guard, every parent
+                // recomposition (e.g. `loading` toggling) would call `loadUrl(url)`
+                // again and snap the WebView back to the original URL, breaking
+                // intra-WebView navigation. See issue #34.
+                var lastLoadedUrl by remember { mutableStateOf<String?>(null) }
                 AndroidView(
                     modifier = Modifier.padding(contentPadding),
                     factory = { context ->
@@ -99,11 +105,15 @@ internal fun WebView(
                                     loading = false
                                 }
                             }
+                            loadUrl(url)
+                            lastLoadedUrl = url
                         }
                     },
                     update = { webView ->
-                        loading = true
-                        webView.loadUrl(url)
+                        if (lastLoadedUrl != url) {
+                            webView.loadUrl(url)
+                            lastLoadedUrl = url
+                        }
                     }
                 )
             }


### PR DESCRIPTION
Closes #34.

## Summary
- Move `loadUrl(url)` into the `AndroidView` `factory` block so the URL is loaded exactly once when the underlying `WebView` is created.
- Guard the `update` lambda with a remembered `lastLoadedUrl` so a reload only happens when the `url` argument actually changes. This preserves intra-WebView navigation across parent recompositions (snackbar/loading toggles, theme/config changes, etc.).
- Drop the `loading = true` write from `update`; `onPageStarted` already sets it. This avoids a self-triggered recomposition ping-pong.

## Subsumes #40
This change also resolves #40 ("loading state mutated inside `AndroidView.update` lambda") by removing the offending `loading = true` write from the `update` lambda. Issue #40 can be closed as a duplicate after merge.

## Test plan
- [x] `./gradlew :feature:webview:test` — passes (module currently has no unit tests; build + compile succeeds).
- [ ] Manual: open a deal, follow a link inside the WebView, toggle theme/config, confirm the WebView does not snap back to the original URL.
- [ ] Manual: re-enter the WebView screen with a new URL and confirm the new URL loads.

🤖 Generated with [Claude Code](https://claude.com/claude-code)