### PR TITLE
fix(#39): prevent stale snackbar retry/reload lambdas in LaunchedEffect

### DIFF
--- a/feature/game/src/main/java/pm/bam/gamedeals/feature/game/ui/GameScreen.kt
+++ b/feature/game/src/main/java/pm/bam/gamedeals/feature/game/ui/GameScreen.kt
@@ -40,7 +40,9 @@ import androidx.compose.material3.rememberTopAppBarState
 import androidx.compose.material3.windowsizeclass.WindowWidthSizeClass
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.layout.ContentScale
@@ -296,6 +298,7 @@ private fun ScreenScaffold(
     val context = LocalContext.current
     val snackbarHostState = remember { SnackbarHostState() }
     val scrollBehavior = TopAppBarDefaults.pinnedScrollBehavior(rememberTopAppBarState())
+    val currentOnRetry by rememberUpdatedState(onRetry)
 
     val title = when (data) {
         GameScreenData.Loading, GameScreenData.Error -> stringResource(R.string.game_screen_toolbar_title_loading)
@@ -344,7 +347,7 @@ private fun ScreenScaffold(
                             actionLabel = context.getString(R.string.game_screen_data_loading_error_retry)
                         )
                         if (results == SnackbarResult.ActionPerformed) {
-                            onRetry()
+                            currentOnRetry()
                         }
                     }
 

--- a/feature/giveaways/src/main/java/pm/bam/gamedeals/feature/giveaways/ui/GiveawaysScreen.kt
+++ b/feature/giveaways/src/main/java/pm/bam/gamedeals/feature/giveaways/ui/GiveawaysScreen.kt
@@ -43,6 +43,7 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.saveable.mapSaver
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
@@ -133,6 +134,7 @@ private fun ScreenScaffold(
     val context = LocalContext.current
     val scrollState = rememberLazyListState()
     val snackbarHostState = remember { SnackbarHostState() }
+    val currentOnReload by rememberUpdatedState(onReload)
 
     GameDealsTheme {
         Surface(color = MaterialTheme.colorScheme.background) {
@@ -197,7 +199,7 @@ private fun ScreenScaffold(
                             actionLabel = context.getString(R.string.giveaway_screen_data_loading_error_retry)
                         )
                         if (results == SnackbarResult.ActionPerformed) {
-                            onReload()
+                            currentOnReload()
                         }
                     }
                 }

--- a/feature/home/src/main/java/pm/bam/gamedeals/feature/home/ui/HomeScreen.kt
+++ b/feature/home/src/main/java/pm/bam/gamedeals/feature/home/ui/HomeScreen.kt
@@ -30,7 +30,9 @@ import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -178,6 +180,7 @@ private fun Screen(
 ) {
     val context = LocalContext.current
     val snackbarHostState = remember { SnackbarHostState() }
+    val currentOnRetry by rememberUpdatedState(onRetry)
 
     GameDealsTheme {
         Surface(color = MaterialTheme.colorScheme.background) {
@@ -293,7 +296,7 @@ private fun Screen(
                         actionLabel = context.getString(R.string.home_screen_data_loading_error_retry)
                     )
                     if (results == SnackbarResult.ActionPerformed) {
-                        onRetry()
+                        currentOnRetry()
                     }
                 }
             }

--- a/feature/search/src/main/java/pm/bam/gamedeals/feature/search/ui/SearchScreen.kt
+++ b/feature/search/src/main/java/pm/bam/gamedeals/feature/search/ui/SearchScreen.kt
@@ -48,6 +48,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableFloatStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.saveable.listSaver
 import androidx.compose.runtime.saveable.mapSaver
 import androidx.compose.runtime.saveable.rememberSaveable
@@ -140,6 +141,7 @@ private fun Screen(
 ) {
     val context = LocalContext.current
     val snackbarHostState = remember { SnackbarHostState() }
+    val currentOnRetry by rememberUpdatedState(onRetry)
 
     GameDealsTheme {
         Surface(color = MaterialTheme.colorScheme.background) {
@@ -207,7 +209,7 @@ private fun Screen(
                 actionLabel = context.getString(R.string.search_screen_data_loading_error_retry)
             )
             if (results == SnackbarResult.ActionPerformed) {
-                onRetry()
+                currentOnRetry()
             }
         }
     }


### PR DESCRIPTION
Closes #39.

## Summary
- Each error-state snackbar uses `LaunchedEffect(snackbarHostState)` with a stable key, while `onRetry`/`onReload` are freshly allocated on every recomposition. The first lambda is captured permanently while `showSnackbar` suspends, masking later updates (e.g. `SearchScreen`'s `onRetry` that closes over `existingParameters`).
- Wrapped each callback with `rememberUpdatedState` and invoke the resulting `currentOnRetry`/`currentOnReload` from inside the `LaunchedEffect`, so the action handler always sees the latest lambda.
- Touched four screens: `HomeScreen.kt`, `GameScreen.kt`, `SearchScreen.kt`, `GiveawaysScreen.kt` (one occurrence each).

## Test plan
- [x] `./gradlew :feature:home:test :feature:game:test :feature:search:test :feature:giveaways:test`

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>

Generated with [Claude Code](https://claude.com/claude-code)