### PR TITLE
fix(#30): destroy WebView on composable disposal

### DIFF
--- a/feature/webview/src/main/java/pm/bam/gamedeals/feature/webview/ui/WebView.kt
+++ b/feature/webview/src/main/java/pm/bam/gamedeals/feature/webview/ui/WebView.kt
@@ -2,6 +2,7 @@ package pm.bam.gamedeals.feature.webview.ui
 
 import android.annotation.SuppressLint
 import android.graphics.Bitmap
+import android.view.ViewGroup
 import android.webkit.WebResourceRequest
 import android.webkit.WebView
 import android.webkit.WebViewClient
@@ -80,28 +81,32 @@ internal fun WebView(
             ) { contentPadding: PaddingValues ->
                 // Track the last URL we loaded so `update` only reloads when the `url` argument actually changes.
                 var lastLoadedUrl by remember { mutableStateOf<String?>(null) }
-                
+
+                val webViewClient = remember {
+                    object : WebViewClient() {
+                        override fun shouldOverrideUrlLoading(view: WebView?, request: WebResourceRequest?): Boolean {
+                            loading = true
+                            return super.shouldOverrideUrlLoading(view, request)
+                        }
+
+                        override fun onPageStarted(view: WebView?, url: String?, favicon: Bitmap?) {
+                            super.onPageStarted(view, url, favicon)
+                            loading = true
+                        }
+
+                        override fun onPageFinished(view: WebView?, url: String?) {
+                            super.onPageFinished(view, url)
+                            loading = false
+                        }
+                    }
+                }
+
                 AndroidView(
                     modifier = Modifier.padding(contentPadding),
                     factory = { context ->
                         WebView(context).apply {
                             settings.javaScriptEnabled = true
-                            this.webViewClient = object : WebViewClient() {
-                                override fun shouldOverrideUrlLoading(view: WebView?, request: WebResourceRequest?): Boolean {
-                                    loading = true
-                                    return super.shouldOverrideUrlLoading(view, request)
-                                }
-
-                                override fun onPageStarted(view: WebView?, url: String?, favicon: Bitmap?) {
-                                    super.onPageStarted(view, url, favicon)
-                                    loading = true
-                                }
-
-                                override fun onPageFinished(view: WebView?, url: String?) {
-                                    super.onPageFinished(view, url)
-                                    loading = false
-                                }
-                            }
+                            this.webViewClient = webViewClient
                             loadUrl(url)
                             lastLoadedUrl = url
                         }
@@ -111,6 +116,14 @@ internal fun WebView(
                             webView.loadUrl(url)
                             lastLoadedUrl = url
                         }
+                    },
+                    onRelease = { webView ->
+                        webView.stopLoading()
+                        webView.webViewClient = WebViewClient()
+                        webView.loadUrl("about:blank")
+                        (webView.parent as? ViewGroup)?.removeView(webView)
+                        webView.removeAllViews()
+                        webView.destroy()
                     }
                 )
             }


### PR DESCRIPTION
Closes #30.

## Summary
- Add an `onRelease` callback to the `AndroidView` hosting the WebView so that when the composable leaves composition (back navigation, configuration change), the WebView is properly torn down: `stopLoading()`, swap in a vanilla `WebViewClient`, navigate to `about:blank`, detach from parent, `removeAllViews()`, then `destroy()`. This releases the renderer process, JS engine state, web-storage handles, and the previously-held `WebViewClient`.
- Hoist the `WebViewClient` out of the `factory` block into a `remember { }` so it isn't recreated on every recomposition and so its lifetime is decoupled from any transient capture inside the factory lambda. The PR #64 logic (`lastLoadedUrl` + conditional `loadUrl()` in `update`) is preserved.

## Test plan
- [x] `:feature:webview:compileDebugKotlin` passes
- [x] `:feature:webview:compileReleaseKotlin` passes
- [x] `:feature:webview:test` passes (module has no JVM unit tests; NO-SOURCE)

Generated with [Claude Code](https://claude.com/claude-code)