### PR TITLE
fix(#36): emit LOADING before awaiting refreshGiveaways

### DIFF
--- a/feature/giveaways/src/main/java/pm/bam/gamedeals/feature/giveaways/ui/GiveawaysViewModel.kt
+++ b/feature/giveaways/src/main/java/pm/bam/gamedeals/feature/giveaways/ui/GiveawaysViewModel.kt
@@ -10,7 +10,6 @@ import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.emitAll
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.map
-import kotlinx.coroutines.flow.onStart
 import kotlinx.coroutines.launch
 import pm.bam.gamedeals.common.logFlow
 import pm.bam.gamedeals.domain.models.Giveaway
@@ -42,8 +41,10 @@ internal class GiveawaysViewModel @Inject constructor(
 
     fun reloadGiveaways() {
         viewModelScope.launch {
-            flow { emit(_uiState.value.copy(status = GiveawaysScreenStatus.LOADING)) }
-                .onStart { giveawaysRepository.refreshGiveaways() }
+            flow {
+                emit(_uiState.value.copy(status = GiveawaysScreenStatus.LOADING))
+                giveawaysRepository.refreshGiveaways()
+            }
                 .logFlow(logger)
                 .catch { emit(_uiState.value.copy(status = GiveawaysScreenStatus.ERROR)) }
                 .collect { _uiState.emit(it) }

--- a/feature/giveaways/src/test/java/pm/bam/gamedeals/feature/giveaways/ui/GiveawaysViewModelTest.kt
+++ b/feature/giveaways/src/test/java/pm/bam/gamedeals/feature/giveaways/ui/GiveawaysViewModelTest.kt
@@ -4,6 +4,7 @@ import io.mockk.coEvery
 import io.mockk.just
 import io.mockk.mockk
 import io.mockk.runs
+import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.TestScope
@@ -68,6 +69,21 @@ class GiveawaysViewModelTest {
 
         // Loading is emitted twice, but observed only once because StateFlow emits only distinct values
         Assert.assertEquals(GiveawaysViewModel.GiveawaysScreenStatus.LOADING, emissions.first().status)
+    }
+
+    @Test
+    fun `reload Giveaways emits LOADING before refresh completes`() = runTest {
+        coEvery { giveawaysRepository.observeGiveaways() } returns flowOf(emptyList())
+        val refreshGate = CompletableDeferred<Unit>()
+        coEvery { giveawaysRepository.refreshGiveaways() } coAnswers { refreshGate.await() }
+
+        val viewModel = GiveawaysViewModel(TestingLoggingListener(), giveawaysRepository)
+        viewModel.reloadGiveaways()
+
+        val emissions = observeStates(viewModel)
+        Assert.assertEquals(GiveawaysViewModel.GiveawaysScreenStatus.LOADING, emissions.last().status)
+
+        refreshGate.complete(Unit)
     }
 
     @Test


### PR DESCRIPTION
Closes #36.

## Summary
- `GiveawaysViewModel.reloadGiveaways` was wrapped as `flow { emit(LOADING) }.onStart { repo.refreshGiveaways() }`, but `onStart` runs *before* the flow body emits. Because `refreshGiveaways()` is suspending, the user-visible order was: subscribe -> block on network -> emit LOADING. The LOADING state arrived in `_uiState` only after the refresh had already finished and was immediately overwritten by the SUCCESS value the `init {}` collector pushed for the refreshed `observeGiveaways()` result. The "show LOADING while refreshing" intent was inverted.
- Inline the `refreshGiveaways()` call after the `emit(LOADING)` inside the `flow {}` builder so collect propagates LOADING into `_uiState` first, then the refresh is awaited. Keeps the handler Flow-shaped per L-2026-04-30-04 (do not lower to `viewModelScope.launch { try/catch }`) and preserves the synchronous-throw safety pattern of L-2026-04-30-05.
- Adds a JVM unit test gated by a `CompletableDeferred` that holds `refreshGiveaways()` suspended while asserting the collector has observed LOADING — this fails against the original `.onStart {}` ordering and passes against the fix.

## Test plan
- [x] `./gradlew :feature:giveaways:test` green (5/5 unit tests pass)
- [x] New test `reload Giveaways emits LOADING before refresh completes` fails against the old `.onStart {}` ordering and passes after the fix (verified locally)

🤖 Generated with [Claude Code](https://claude.com/claude-code)