### PR TITLE
fix(#38): annotate + migrate screen state to ImmutableList

### DIFF
--- a/feature/game/build.gradle.kts
+++ b/feature/game/build.gradle.kts
@@ -13,6 +13,7 @@ dependencies {
     implementation(project(":common:ui"))
     implementation(project(":feature:deal"))
     implementation(libs.compose.material.icons)
+    implementation(libs.kotlinx.collections.immutable)
     implementation(libs.androidx.tracing) {
         because("Pulled in by libs.androidx.espresso.device — see " +
                 "https://github.com/android/android-test/issues/1755#issuecomment-1523810698")

--- a/feature/game/src/androidTest/java/pm/bam/gamedeals/feature/game/ui/GameScreenTest.kt
+++ b/feature/game/src/androidTest/java/pm/bam/gamedeals/feature/game/ui/GameScreenTest.kt
@@ -16,6 +16,7 @@ import io.mockk.just
 import io.mockk.mockk
 import io.mockk.runs
 import io.mockk.verify
+import kotlinx.collections.immutable.persistentListOf
 import kotlinx.coroutines.flow.MutableStateFlow
 import org.junit.Before
 import org.junit.Rule
@@ -142,7 +143,7 @@ class GameScreenTest {
         every { viewModel.uiState } returns MutableStateFlow(
             GameViewModel.GameScreenData.Data(
                 gameDetails = gameDetails,
-                dealDetails = listOf(store to gameDeal)
+                dealDetails = persistentListOf(store to gameDeal)
             )
         )
 
@@ -186,7 +187,7 @@ class GameScreenTest {
         every { viewModel.uiState } returns MutableStateFlow(
             GameViewModel.GameScreenData.Data(
                 gameDetails = gameDetails,
-                dealDetails = listOf(store to gameDeal)
+                dealDetails = persistentListOf(store to gameDeal)
             )
         )
 

--- a/feature/game/src/main/java/pm/bam/gamedeals/feature/game/ui/GameScreen.kt
+++ b/feature/game/src/main/java/pm/bam/gamedeals/feature/game/ui/GameScreen.kt
@@ -55,6 +55,7 @@ import androidx.compose.ui.unit.dp
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import coil.compose.AsyncImage
+import kotlinx.collections.immutable.toImmutableList
 import pm.bam.gamedeals.common.ui.FoldableLandscape
 import pm.bam.gamedeals.common.ui.FoldablePortrait
 import pm.bam.gamedeals.common.ui.PhoneLandscape
@@ -396,7 +397,7 @@ private fun PreviewCompact() {
         windowWidth = WindowWidthSizeClass.Compact,
         data = GameScreenData.Data(
             gameDetails = PreviewGameDetails,
-            dealDetails = List(19) { PreviewStore to PreviewGameDeal }
+            dealDetails = List(19) { PreviewStore to PreviewGameDeal }.toImmutableList()
         ),
         onBack = {},
         goToWeb = { _, _ -> },
@@ -412,7 +413,7 @@ private fun PreviewMedium() {
         windowWidth = WindowWidthSizeClass.Medium,
         data = GameScreenData.Data(
             gameDetails = PreviewGameDetails,
-            dealDetails = List(19) { PreviewStore to PreviewGameDeal }
+            dealDetails = List(19) { PreviewStore to PreviewGameDeal }.toImmutableList()
         ),
         onBack = {},
         goToWeb = { _, _ -> },
@@ -429,7 +430,7 @@ private fun PreviewExpanded() {
         windowWidth = WindowWidthSizeClass.Expanded,
         data = GameScreenData.Data(
             gameDetails = PreviewGameDetails,
-            dealDetails = List(19) { PreviewStore to PreviewGameDeal }
+            dealDetails = List(19) { PreviewStore to PreviewGameDeal }.toImmutableList()
         ),
         onBack = {},
         goToWeb = { _, _ -> },

--- a/feature/game/src/main/java/pm/bam/gamedeals/feature/game/ui/GameViewModel.kt
+++ b/feature/game/src/main/java/pm/bam/gamedeals/feature/game/ui/GameViewModel.kt
@@ -1,9 +1,12 @@
 package pm.bam.gamedeals.feature.game.ui
 
+import androidx.compose.runtime.Immutable
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.collections.immutable.ImmutableList
+import kotlinx.collections.immutable.toImmutableList
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -70,7 +73,7 @@ internal class GameViewModel @Inject constructor(
             .flatMapLatest { details ->
                 details.deals
                     .map { deal -> storesRepository.getStore(deal.storeID) to deal }
-                    .let { dealDetails -> GameScreenData.Data(details, dealDetails) }
+                    .let { dealDetails -> GameScreenData.Data(details, dealDetails.toImmutableList()) }
                     .toFlow<GameScreenData>()
             }
             .onStart { _uiState.emit(GameScreenData.Loading) }
@@ -81,9 +84,11 @@ internal class GameViewModel @Inject constructor(
     sealed class GameScreenData {
         data object Loading : GameScreenData()
         data object Error : GameScreenData()
+
+        @Immutable
         data class Data(
             val gameDetails: GameDetails,
-            val dealDetails: List<Pair<Store, GameDetails.GameDeal>>
+            val dealDetails: ImmutableList<Pair<Store, GameDetails.GameDeal>>
         ) : GameScreenData()
     }
 }

--- a/feature/game/src/test/java/pm/bam/gamedeals/feature/game/ui/GameViewModelTest.kt
+++ b/feature/game/src/test/java/pm/bam/gamedeals/feature/game/ui/GameViewModelTest.kt
@@ -4,6 +4,7 @@ import androidx.lifecycle.SavedStateHandle
 import io.mockk.coEvery
 import io.mockk.every
 import io.mockk.mockk
+import kotlinx.collections.immutable.persistentListOf
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.test.runTest
@@ -93,7 +94,7 @@ class GameViewModelTest {
 
         assertEquals(2, emissions.size)
         assertEquals(GameViewModel.GameScreenData.Loading, emissions.first())
-        assertEquals(GameViewModel.GameScreenData.Data(gameDetails, listOf(store to gameDeals)), emissions.second())
+        assertEquals(GameViewModel.GameScreenData.Data(gameDetails, persistentListOf(store to gameDeals)), emissions.second())
     }
 
 
@@ -119,6 +120,6 @@ class GameViewModelTest {
 
         assertEquals(2, emissions.size)
         assertEquals(GameViewModel.GameScreenData.Loading, emissions.first())
-        assertEquals(GameViewModel.GameScreenData.Data(gameDetails, listOf(store to gameDeals)), emissions.second())
+        assertEquals(GameViewModel.GameScreenData.Data(gameDetails, persistentListOf(store to gameDeals)), emissions.second())
     }
 }

--- a/feature/giveaways/build.gradle.kts
+++ b/feature/giveaways/build.gradle.kts
@@ -12,6 +12,7 @@ dependencies {
     implementation(project(":common"))
     implementation(project(":common:ui"))
     implementation(libs.compose.material.icons)
+    implementation(libs.kotlinx.collections.immutable)
 
     testImplementation(project(":testing"))
 }

--- a/feature/giveaways/src/androidTest/java/pm/bam/gamedeals/feature/giveaways/ui/GiveawaysScreenTest.kt
+++ b/feature/giveaways/src/androidTest/java/pm/bam/gamedeals/feature/giveaways/ui/GiveawaysScreenTest.kt
@@ -11,6 +11,7 @@ import io.mockk.every
 import io.mockk.just
 import io.mockk.mockk
 import io.mockk.verify
+import kotlinx.collections.immutable.persistentListOf
 import kotlinx.coroutines.flow.MutableStateFlow
 import org.junit.Rule
 import org.junit.Test
@@ -100,7 +101,7 @@ class GiveawaysScreenTest {
         every { viewModel.uiState } returns MutableStateFlow(
             GiveawaysViewModel.GiveawaysScreenData(
                 status = GiveawaysViewModel.GiveawaysScreenStatus.SUCCESS,
-                giveaways = listOf(giveaway)
+                giveaways = persistentListOf(giveaway)
             )
         )
 

--- a/feature/giveaways/src/main/java/pm/bam/gamedeals/feature/giveaways/ui/GiveawaysScreen.kt
+++ b/feature/giveaways/src/main/java/pm/bam/gamedeals/feature/giveaways/ui/GiveawaysScreen.kt
@@ -66,6 +66,7 @@ import androidx.compose.ui.unit.dp
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import coil.compose.AsyncImage
+import kotlinx.collections.immutable.persistentListOf
 import pm.bam.gamedeals.common.ui.PhonePortrait
 import pm.bam.gamedeals.common.ui.PreviewGiveaway
 import pm.bam.gamedeals.common.ui.theme.GameDealsCustomTheme
@@ -447,7 +448,7 @@ private fun PreviewData() {
     ScreenScaffold(
         data = GiveawaysViewModel.GiveawaysScreenData(
             status = GiveawaysViewModel.GiveawaysScreenStatus.SUCCESS,
-            giveaways = listOf(
+            giveaways = persistentListOf(
                 PreviewGiveaway.copy(id = 1),
                 PreviewGiveaway.copy(id = 2).copy(worthDenominated = null),
                 PreviewGiveaway.copy(id = 3),

--- a/feature/giveaways/src/main/java/pm/bam/gamedeals/feature/giveaways/ui/GiveawaysViewModel.kt
+++ b/feature/giveaways/src/main/java/pm/bam/gamedeals/feature/giveaways/ui/GiveawaysViewModel.kt
@@ -1,8 +1,12 @@
 package pm.bam.gamedeals.feature.giveaways.ui
 
+import androidx.compose.runtime.Immutable
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.collections.immutable.ImmutableList
+import kotlinx.collections.immutable.persistentListOf
+import kotlinx.collections.immutable.toImmutableList
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -32,7 +36,7 @@ internal class GiveawaysViewModel @Inject constructor(
     init {
         viewModelScope.launch {
             flow { emitAll(giveawaysRepository.observeGiveaways()) }
-                .map { GiveawaysScreenData(status = GiveawaysScreenStatus.SUCCESS, giveaways = it) }
+                .map { GiveawaysScreenData(status = GiveawaysScreenStatus.SUCCESS, giveaways = it.toImmutableList()) }
                 .logFlow(logger)
                 .catch { emit(_uiState.value.copy(status = GiveawaysScreenStatus.ERROR)) }
                 .collect { _uiState.emit(it) }
@@ -54,7 +58,7 @@ internal class GiveawaysViewModel @Inject constructor(
     fun loadGiveaway(parameters: GiveawaySearchParameters) {
         viewModelScope.launch {
             flow { emitAll(giveawaysRepository.observeGiveaways(parameters)) }
-                .map { GiveawaysScreenData(status = GiveawaysScreenStatus.SUCCESS, giveaways = it) }
+                .map { GiveawaysScreenData(status = GiveawaysScreenStatus.SUCCESS, giveaways = it.toImmutableList()) }
                 .logFlow(logger)
                 .catch { emit(_uiState.value.copy(status = GiveawaysScreenStatus.ERROR)) }
                 .collect { _uiState.emit(it) }
@@ -62,9 +66,10 @@ internal class GiveawaysViewModel @Inject constructor(
     }
 
 
+    @Immutable
     data class GiveawaysScreenData(
         val status: GiveawaysScreenStatus = GiveawaysScreenStatus.LOADING,
-        val giveaways: List<Giveaway> = emptyList()
+        val giveaways: ImmutableList<Giveaway> = persistentListOf()
     )
 
 

--- a/feature/home/build.gradle.kts
+++ b/feature/home/build.gradle.kts
@@ -12,6 +12,7 @@ dependencies {
     implementation(project(":common"))
     implementation(project(":common:ui"))
     implementation(libs.compose.material.icons)
+    implementation(libs.kotlinx.collections.immutable)
     implementation(libs.androidx.tracing) {
         because("Pulled in by libs.androidx.espresso.device — see " +
                 "https://github.com/android/android-test/issues/1755#issuecomment-1523810698")

--- a/feature/home/src/androidTest/java/pm/bam/gamedeals/feature/home/ui/HomeScreenTest.kt
+++ b/feature/home/src/androidTest/java/pm/bam/gamedeals/feature/home/ui/HomeScreenTest.kt
@@ -12,6 +12,7 @@ import androidx.test.espresso.device.action.ScreenOrientation
 import androidx.test.espresso.device.rules.ScreenOrientationRule
 import io.mockk.every
 import io.mockk.mockk
+import kotlinx.collections.immutable.persistentListOf
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asSharedFlow
@@ -149,7 +150,7 @@ class HomeScreenTest {
 
     @Test
     fun storeDataLoaded() {
-        val mockData = HomeScreenData(state = HomeScreenStatus.SUCCESS, items = listOf(mockStoreData, mockDealData, mockViewAllData))
+        val mockData = HomeScreenData(state = HomeScreenStatus.SUCCESS, items = persistentListOf(mockStoreData, mockDealData, mockViewAllData))
 
         every { viewModel.uiState } returns MutableStateFlow(mockData)
 

--- a/feature/home/src/main/java/pm/bam/gamedeals/feature/home/ui/HomeScreen.kt
+++ b/feature/home/src/main/java/pm/bam/gamedeals/feature/home/ui/HomeScreen.kt
@@ -49,6 +49,7 @@ import androidx.compose.ui.unit.dp
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import coil.compose.AsyncImage
+import kotlinx.collections.immutable.persistentListOf
 import pm.bam.gamedeals.common.SingleEventEffect
 import pm.bam.gamedeals.common.ui.FoldableLandscape
 import pm.bam.gamedeals.common.ui.FoldablePortrait
@@ -427,9 +428,9 @@ private fun ScreenEmptyPreview() {
         onReleaseTitle = {},
         data = HomeViewModel.HomeScreenData(
             state = LOADING,
-            releases = listOf(),
-            giveaways = listOf(),
-            items = listOf()
+            releases = persistentListOf(),
+            giveaways = persistentListOf(),
+            items = persistentListOf()
         ),
         dealDetails = null,
         onViewDealDetails = { _, _, _, _ -> },
@@ -454,21 +455,21 @@ private fun ScreenPreview() {
         onReleaseTitle = {},
         data = HomeViewModel.HomeScreenData(
             state = SUCCESS,
-            releases = listOf(
+            releases = persistentListOf(
                 PreviewRelease.copy(title = "Game 1"),
                 PreviewRelease.copy(title = "Game 2"),
                 PreviewRelease.copy(title = "Game 3"),
                 PreviewRelease.copy(title = "Game 4"),
                 PreviewRelease.copy(title = "Game 5"),
             ),
-            giveaways = listOf(
+            giveaways = persistentListOf(
                 PreviewGiveaway.copy(id = 1, title = "Giveaway 1"),
                 PreviewGiveaway.copy(id = 2, title = "Giveaway 2"),
                 PreviewGiveaway.copy(id = 3, title = "Giveaway 3 - Very long title with even more title to make it longer, possibly over many, many lines"),
                 PreviewGiveaway.copy(id = 4, title = "Giveaway 4"),
                 PreviewGiveaway.copy(id = 5, title = "Giveaway 5"),
             ),
-            items = listOf(
+            items = persistentListOf(
                 StoreData(store = PreviewStore.copy(storeID = 1)),
                 DealData(deal = PreviewDeal.copy(dealID = "deal-1-a")),
                 ViewAllData(store = PreviewStore.copy(storeID = 1)),

--- a/feature/home/src/main/java/pm/bam/gamedeals/feature/home/ui/HomeViewModel.kt
+++ b/feature/home/src/main/java/pm/bam/gamedeals/feature/home/ui/HomeViewModel.kt
@@ -1,8 +1,12 @@
 package pm.bam.gamedeals.feature.home.ui
 
+import androidx.compose.runtime.Immutable
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.collections.immutable.ImmutableList
+import kotlinx.collections.immutable.persistentListOf
+import kotlinx.collections.immutable.toImmutableList
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.channels.BufferOverflow
@@ -121,7 +125,14 @@ internal class HomeViewModel @Inject constructor(
             }
             .flatMapLatest { loadNewReleases().map { releases -> releases to it } }
             .flatMapLatest { loadGiveaways().map { giveaways -> Triple(it.first, giveaways.take(LIMIT_GIVEAWAYS), it.second) } }
-            .map { HomeScreenData(state = HomeScreenStatus.SUCCESS, releases = it.first, giveaways = it.second, items = it.third) }
+            .map {
+                HomeScreenData(
+                    state = HomeScreenStatus.SUCCESS,
+                    releases = it.first.toImmutableList(),
+                    giveaways = it.second.toImmutableList(),
+                    items = it.third.toImmutableList()
+                )
+            }
             .logFlow(logger)
             .catch { emit(HomeScreenData(state = HomeScreenStatus.ERROR)) }
 
@@ -140,11 +151,12 @@ internal class HomeViewModel @Inject constructor(
         data class NavigateToGame(val gameId: Int) : HomeUiEvent
     }
 
+    @Immutable
     internal data class HomeScreenData(
         val state: HomeScreenStatus = HomeScreenStatus.LOADING,
-        val releases: List<Release> = emptyList(),
-        val giveaways: List<Giveaway> = emptyList(),
-        val items: List<HomeScreenListData> = emptyList()
+        val releases: ImmutableList<Release> = persistentListOf(),
+        val giveaways: ImmutableList<Giveaway> = persistentListOf(),
+        val items: ImmutableList<HomeScreenListData> = persistentListOf()
     )
 
     internal enum class HomeScreenStatus {

--- a/feature/home/src/test/java/pm/bam/gamedeals/feature/home/ui/HomeViewModelTest.kt
+++ b/feature/home/src/test/java/pm/bam/gamedeals/feature/home/ui/HomeViewModelTest.kt
@@ -5,6 +5,7 @@ import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.mockk
+import kotlinx.collections.immutable.toImmutableList
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.flowOf
@@ -97,7 +98,7 @@ class HomeViewModelTest {
 
         assertEquals(1, emissions.size)
         assertNotNull(emissions.first())
-        assertEquals(HomeScreenData(state = HomeScreenStatus.SUCCESS, items = data), emissions.first())
+        assertEquals(HomeScreenData(state = HomeScreenStatus.SUCCESS, items = data.toImmutableList()), emissions.first())
 
 
         coVerify(exactly = 1) { storesRepository.observeStores() }

--- a/feature/search/build.gradle.kts
+++ b/feature/search/build.gradle.kts
@@ -12,6 +12,7 @@ dependencies {
     implementation(project(":common"))
     implementation(project(":common:ui"))
     implementation(libs.compose.material.icons)
+    implementation(libs.kotlinx.collections.immutable)
 
     testImplementation(project(":testing"))
 }

--- a/feature/search/src/androidTest/java/pm/bam/gamedeals/feature/search/ui/SearchScreenTest.kt
+++ b/feature/search/src/androidTest/java/pm/bam/gamedeals/feature/search/ui/SearchScreenTest.kt
@@ -19,6 +19,7 @@ import io.mockk.every
 import io.mockk.just
 import io.mockk.mockk
 import io.mockk.verify
+import kotlinx.collections.immutable.persistentListOf
 import kotlinx.coroutines.flow.MutableStateFlow
 import org.junit.Rule
 import org.junit.Test
@@ -152,7 +153,7 @@ class SearchScreenTest {
             every { salePriceDenominated } returns dealSalePriceDenominated
             every { thumb } returns "Thumb"
         }
-        val data = SearchViewModel.SearchData.SearchResults(listOf(singleDeal))
+        val data = SearchViewModel.SearchData.SearchResults(persistentListOf(singleDeal))
 
         every { searchViewModel.resultState } returns MutableStateFlow(data)
 

--- a/feature/search/src/main/java/pm/bam/gamedeals/feature/search/ui/SearchScreen.kt
+++ b/feature/search/src/main/java/pm/bam/gamedeals/feature/search/ui/SearchScreen.kt
@@ -71,6 +71,7 @@ import androidx.compose.ui.unit.dp
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import coil.compose.AsyncImage
+import kotlinx.collections.immutable.toImmutableList
 import kotlinx.serialization.ExperimentalSerializationApi
 import pm.bam.gamedeals.common.ui.PhoneLandscape
 import pm.bam.gamedeals.common.ui.PhonePortrait
@@ -462,7 +463,7 @@ private fun SearchScreenPreview() {
         onShowFiltersChanged = {},
         existingSearchParameters = SearchParameters(),
         searchData = SearchViewModel.SearchData.SearchResults(
-            searchResults = List(15) { PreviewDeal.copy(dealID = "$it") }
+            searchResults = List(15) { PreviewDeal.copy(dealID = "$it") }.toImmutableList()
         ),
         onSearchTitleChanged = {},
         onSearchedGame = {},

--- a/feature/search/src/main/java/pm/bam/gamedeals/feature/search/ui/SearchViewModel.kt
+++ b/feature/search/src/main/java/pm/bam/gamedeals/feature/search/ui/SearchViewModel.kt
@@ -1,8 +1,11 @@
 package pm.bam.gamedeals.feature.search.ui
 
+import androidx.compose.runtime.Immutable
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.collections.immutable.ImmutableList
+import kotlinx.collections.immutable.toImmutableList
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -48,7 +51,7 @@ internal class SearchViewModel @Inject constructor(
                             .map {
                                 when (it.isEmpty()) {
                                     true -> SearchData.NoResults
-                                    false -> SearchData.SearchResults(it)
+                                    false -> SearchData.SearchResults(it.toImmutableList())
                                 }
                             }
                     }
@@ -84,8 +87,10 @@ internal class SearchViewModel @Inject constructor(
         data object Loading : SearchData()
         data object NoResults : SearchData()
         data object Error : SearchData()
+
+        @Immutable
         data class SearchResults(
-            val searchResults: List<Deal>
+            val searchResults: ImmutableList<Deal>
         ) : SearchData()
     }
 }

--- a/feature/search/src/test/java/pm/bam/gamedeals/feature/search/ui/SearchViewModelTest.kt
+++ b/feature/search/src/test/java/pm/bam/gamedeals/feature/search/ui/SearchViewModelTest.kt
@@ -2,6 +2,7 @@ package pm.bam.gamedeals.feature.search.ui
 
 import io.mockk.coEvery
 import io.mockk.mockk
+import kotlinx.collections.immutable.toImmutableList
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.test.TestScope
@@ -90,7 +91,7 @@ class SearchViewModelTest {
 
         delay(1200) // Delay because Flow 'flatMapLatestDelayAtLeast'
 
-        assertEquals(SearchData.SearchResults(deals), emissions.third())
+        assertEquals(SearchData.SearchResults(deals.toImmutableList()), emissions.third())
     }
 
     @Test

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -37,6 +37,7 @@ sandwich = "2.1.3"
 
 kotlinx = '1.9.0'
 kotlinx-retrofit = "1.0.0"
+kotlinx-collections-immutable = "0.4.0"
 
 room = '2.8.3'
 
@@ -114,6 +115,7 @@ sandwich-serializer = { group = "com.github.skydoves", name = "sandwich-retrofit
 kotlinx = { group = "org.jetbrains.kotlinx", name = "kotlinx-serialization-json", version.ref = "kotlinx" }
 kotlinx-properties = { group = "org.jetbrains.kotlinx", name = "kotlinx-serialization-properties", version.ref = "kotlinx" }
 kotlinx-retrofit = { group = "com.jakewharton.retrofit", name = "retrofit2-kotlinx-serialization-converter", version.ref = "kotlinx-retrofit" }
+kotlinx-collections-immutable = { group = "org.jetbrains.kotlinx", name = "kotlinx-collections-immutable", version.ref = "kotlinx-collections-immutable" }
 
 # Room
 room = { group = "androidx.room", name = "room-runtime", version.ref = "room" }


### PR DESCRIPTION
Closes #38.

## Summary

Applied **both** complementary fixes per direction:

1. Annotated screen state containers (`HomeScreenData`, `GiveawaysScreenData`, `SearchData.SearchResults`, `GameScreenData.Data`) with `androidx.compose.runtime.@Immutable`.
2. Migrated every `List<...>` field on those state classes to `kotlinx.collections.immutable.ImmutableList<...>`. Empty defaults use `persistentListOf()`; producers convert with `.toImmutableList()`; literal call sites (previews/tests) use `persistentListOf(...)`.

This is the belt-and-suspenders variant: `ImmutableList` gives the type-system guarantee, `@Immutable` advertises stability so any composable taking these as parameters is now both restartable and skippable. Added `kotlinx-collections-immutable` 0.4.0 to the catalog and to the four affected feature modules (`home`, `giveaways`, `search`, `game`).

For `GameScreenData.Data.dealDetails: List<Pair<Store, GameDetails.GameDeal>>` the conservative path was taken (migrate to `ImmutableList<Pair<...>>` + `@Immutable` on the container) without refactoring the inner `Pair` — `Pair` is still unstable, but skipping is now driven by the container's identity rather than the kotlin.collections.List type.

## Test plan

- [x] `:feature:home:test` passes
- [x] `:feature:giveaways:test` passes
- [x] `:feature:search:test` passes
- [x] `:feature:game:test` passes
- [x] `:feature:{home,giveaways,search,game}:compileDebugAndroidTestKotlin` succeed