### PR TITLE
fix(#78): use MutableStateFlow.update {} for atomic state mutations

### DIFF
--- a/feature/giveaways/src/main/java/pm/bam/gamedeals/feature/giveaways/ui/GiveawaysViewModel.kt
+++ b/feature/giveaways/src/main/java/pm/bam/gamedeals/feature/giveaways/ui/GiveawaysViewModel.kt
@@ -14,6 +14,7 @@ import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.emitAll
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import pm.bam.gamedeals.common.logFlow
 import pm.bam.gamedeals.domain.models.Giveaway
@@ -38,20 +39,20 @@ internal class GiveawaysViewModel @Inject constructor(
             flow { emitAll(giveawaysRepository.observeGiveaways()) }
                 .map { GiveawaysScreenData(status = GiveawaysScreenStatus.SUCCESS, giveaways = it.toImmutableList()) }
                 .logFlow(logger)
-                .catch { emit(_uiState.value.copy(status = GiveawaysScreenStatus.ERROR)) }
-                .collect { _uiState.emit(it) }
+                .catch { _uiState.update { current -> current.copy(status = GiveawaysScreenStatus.ERROR) } }
+                .collect { newState -> _uiState.emit(newState) }
         }
     }
 
     fun reloadGiveaways() {
         viewModelScope.launch {
-            flow {
-                emit(_uiState.value.copy(status = GiveawaysScreenStatus.LOADING))
+            flow<Unit> {
+                _uiState.update { current -> current.copy(status = GiveawaysScreenStatus.LOADING) }
                 giveawaysRepository.refreshGiveaways()
             }
                 .logFlow(logger)
-                .catch { emit(_uiState.value.copy(status = GiveawaysScreenStatus.ERROR)) }
-                .collect { _uiState.emit(it) }
+                .catch { _uiState.update { current -> current.copy(status = GiveawaysScreenStatus.ERROR) } }
+                .collect { }
         }
     }
 
@@ -60,8 +61,8 @@ internal class GiveawaysViewModel @Inject constructor(
             flow { emitAll(giveawaysRepository.observeGiveaways(parameters)) }
                 .map { GiveawaysScreenData(status = GiveawaysScreenStatus.SUCCESS, giveaways = it.toImmutableList()) }
                 .logFlow(logger)
-                .catch { emit(_uiState.value.copy(status = GiveawaysScreenStatus.ERROR)) }
-                .collect { _uiState.emit(it) }
+                .catch { _uiState.update { current -> current.copy(status = GiveawaysScreenStatus.ERROR) } }
+                .collect { newState -> _uiState.emit(newState) }
         }
     }
 

--- a/feature/home/src/main/java/pm/bam/gamedeals/feature/home/ui/HomeViewModel.kt
+++ b/feature/home/src/main/java/pm/bam/gamedeals/feature/home/ui/HomeViewModel.kt
@@ -24,6 +24,7 @@ import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.onCompletion
 import kotlinx.coroutines.flow.onStart
+import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import pm.bam.gamedeals.common.logFlow
 import pm.bam.gamedeals.common.onError
@@ -80,21 +81,21 @@ internal class HomeViewModel @Inject constructor(
         loadJob?.cancel()
         loadJob = viewModelScope.launch {
             loadTopStoreDataFlow()
-                .onStart { emit(_uiState.value.copy(state = HomeScreenStatus.LOADING)) }
-                .collect { _uiState.emit(it) }
+                .onStart { _uiState.update { it.copy(state = HomeScreenStatus.LOADING) } }
+                .collect { newState -> _uiState.emit(newState) }
         }
     }
 
     fun onReleaseGame(releaseTitle: String) =
         viewModelScope.launch {
             flow { emit(gamesRepository.getReleaseGameId(releaseTitle)) }
-                .onStart { _uiState.emit(_uiState.value.copy(state = HomeScreenStatus.LOADING)) }
+                .onStart { _uiState.update { it.copy(state = HomeScreenStatus.LOADING) } }
                 .map { gameId -> gameId ?: throw IllegalStateException("Game not found") }
                 .onError { fatal(logger, it) }
                 .onCompletion {
                     when (it == null) {
-                        true -> _uiState.emit(_uiState.value.copy(state = HomeScreenStatus.SUCCESS))
-                        else -> _uiState.emit(_uiState.value.copy(state = HomeScreenStatus.ERROR))
+                        true -> _uiState.update { current -> current.copy(state = HomeScreenStatus.SUCCESS) }
+                        else -> _uiState.update { current -> current.copy(state = HomeScreenStatus.ERROR) }
                     }
                 }
                 .collect { _events.emit(HomeUiEvent.NavigateToGame(it)) }


### PR DESCRIPTION
Closes #78.

## Summary
Replace read-modify-write `_uiState.value.copy(...)` patterns in `HomeViewModel` and `GiveawaysViewModel` with `MutableStateFlow.update {}`, the documented atomic CAS helper. This prevents the lost-update race where a long-lived collector and a user-triggered handler can each read the same snapshot, mutate independent fields, and clobber each other on emit.

Changes:
- `HomeViewModel`: `loadTopStoresDeals`, `onReleaseGame` (onStart + onCompletion success/error branches) now use `_uiState.update { it.copy(...) }`.
- `GiveawaysViewModel`: init collector, `reloadGiveaways`, and `loadGiveaway` `.catch` blocks now use `_uiState.update { ... }`. The `reloadGiveaways` flow body invokes `update` directly (and is now typed `flow<Unit>`) since the loading transition is a side effect rather than an emitted value.
- The downstream `.collect { _uiState.emit(it) }` for the success path is preserved because those emissions are full-state replacements, not field-level merges.

## Test plan
- [x] `./gradlew :feature:home:testDebugUnitTest :feature:giveaways:testDebugUnitTest` passes (existing tests cover loading/success/error transitions and the relaunch-cancellation behaviour).

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>

Generated with [Claude Code](https://claude.com/claude-code)