### PR TITLE
fix(#79): annotate GiveawaySearchParameters @Immutable + migrate to ImmutableList

### DIFF
--- a/domain/build.gradle.kts
+++ b/domain/build.gradle.kts
@@ -18,6 +18,7 @@ dependencies {
     implementation(libs.material)
 
     implementation(libs.coroutines)
+    implementation(libs.kotlinx.collections.immutable)
 
     implementation(libs.hilt.android)
     implementation(libs.hilt.navigation.compose)

--- a/domain/src/main/java/pm/bam/gamedeals/domain/models/Giveaway.kt
+++ b/domain/src/main/java/pm/bam/gamedeals/domain/models/Giveaway.kt
@@ -1,8 +1,11 @@
 package pm.bam.gamedeals.domain.models
 
 
+import androidx.compose.runtime.Immutable
 import androidx.room.Entity
 import androidx.room.PrimaryKey
+import kotlinx.collections.immutable.ImmutableList
+import kotlinx.collections.immutable.toImmutableList
 import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
@@ -125,10 +128,13 @@ enum class GiveawaySortBy {
 
 
 @OptIn(ExperimentalSerializationApi::class)
+@Immutable
 @Serializable
 data class GiveawaySearchParameters(
-    val platforms: List<Pair<GiveawayPlatform, Boolean>> = GiveawayPlatform.entries.map { it to false },
-    val types: List<Pair<GiveawayType, Boolean>> = GiveawayType.entries.map { it to false },
+    val platforms: ImmutableList<Pair<GiveawayPlatform, Boolean>> =
+        GiveawayPlatform.entries.map { it to false }.toImmutableList(),
+    val types: ImmutableList<Pair<GiveawayType, Boolean>> =
+        GiveawayType.entries.map { it to false }.toImmutableList(),
     val sortBy: GiveawaySortBy = GiveawaySortBy.DATE,
 ) {
     /**

--- a/domain/src/test/java/pm/bam/gamedeals/domain/repositories/giveaway/GiveawaysRepositoryTest.kt
+++ b/domain/src/test/java/pm/bam/gamedeals/domain/repositories/giveaway/GiveawaysRepositoryTest.kt
@@ -8,6 +8,7 @@ import io.mockk.every
 import io.mockk.just
 import io.mockk.mockk
 import io.mockk.verify
+import kotlinx.collections.immutable.persistentListOf
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.runTest
@@ -99,8 +100,8 @@ class GiveawaysRepositoryTest {
         every { giveawaysDao.observeAllGiveaways() } returns flowOf(listOf(resultOne, resultTwo, resultThree))
 
         val para = GiveawaySearchParameters(
-            types = listOf(GiveawayType.GAME to true, GiveawayType.BETA to true),
-            platforms = listOf(GiveawayPlatform.PC to true, GiveawayPlatform.NINTENDO_SWITCH to true),
+            types = persistentListOf(GiveawayType.GAME to true, GiveawayType.BETA to true),
+            platforms = persistentListOf(GiveawayPlatform.PC to true, GiveawayPlatform.NINTENDO_SWITCH to true),
             sortBy = GiveawaySortBy.DATE
         )
 

--- a/feature/giveaways/src/main/java/pm/bam/gamedeals/feature/giveaways/ui/GiveawaysScreen.kt
+++ b/feature/giveaways/src/main/java/pm/bam/gamedeals/feature/giveaways/ui/GiveawaysScreen.kt
@@ -67,6 +67,7 @@ import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import coil.compose.AsyncImage
 import kotlinx.collections.immutable.persistentListOf
+import kotlinx.collections.immutable.toImmutableList
 import pm.bam.gamedeals.common.ui.PhonePortrait
 import pm.bam.gamedeals.common.ui.PreviewGiveaway
 import pm.bam.gamedeals.common.ui.theme.GameDealsCustomTheme
@@ -105,11 +106,15 @@ internal fun GiveawaysScreen(
         },
         onPlatformSelection = { platform, selection ->
             existingParameters = existingParameters.copy(
-                platforms = existingParameters.platforms.toMutableList().map { if (it.first == platform) platform to selection else it })
+                platforms = existingParameters.platforms
+                    .map { if (it.first == platform) platform to selection else it }
+                    .toImmutableList())
         },
         onTypeSelection = { type, selection ->
             existingParameters = existingParameters.copy(
-                types = existingParameters.types.toMutableList().map { if (it.first == type) type to selection else it })
+                types = existingParameters.types
+                    .map { if (it.first == type) type to selection else it }
+                    .toImmutableList())
         },
         onSortBySelection = { sortBy ->
             existingParameters = existingParameters.copy(sortBy = sortBy)

--- a/feature/giveaways/src/test/java/pm/bam/gamedeals/feature/giveaways/ui/GiveawaysViewModelTest.kt
+++ b/feature/giveaways/src/test/java/pm/bam/gamedeals/feature/giveaways/ui/GiveawaysViewModelTest.kt
@@ -4,6 +4,7 @@ import io.mockk.coEvery
 import io.mockk.just
 import io.mockk.mockk
 import io.mockk.runs
+import kotlinx.collections.immutable.persistentListOf
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.flowOf
@@ -94,8 +95,8 @@ class GiveawaysViewModelTest {
 
 
         val para = GiveawaySearchParameters(
-            types = listOf(GiveawayType.GAME to true, GiveawayType.BETA to true),
-            platforms = listOf(GiveawayPlatform.PC to true, GiveawayPlatform.NINTENDO_SWITCH to true),
+            types = persistentListOf(GiveawayType.GAME to true, GiveawayType.BETA to true),
+            platforms = persistentListOf(GiveawayPlatform.PC to true, GiveawayPlatform.NINTENDO_SWITCH to true),
             sortBy = GiveawaySortBy.DATE
         )
 


### PR DESCRIPTION
Closes #79.

## Summary

`GiveawaySearchParameters` carried `platforms: List<Pair<...>>` and `types: List<Pair<...>>` — raw `kotlin.collections.List`, which Compose treats as unstable. Together with the missing `@Immutable` annotation, this defeated skipping for `ScreenScaffold`, `GiveawayFilters`, `Filters`, and `GiveawaySortByOptions`, so they all rebuilt on every recomposition of `GiveawaysScreen` (e.g. when `uiState.giveaways` updates while the filter sheet is open).

This is the same class of issue addressed in #38 / PR #70 — these filter parameters were missed.

## Change

- `domain/.../Giveaway.kt`: annotate `GiveawaySearchParameters` with `@Immutable` and re-type `platforms` / `types` as `ImmutableList<Pair<..., Boolean>>` (`kotlinx.collections.immutable`).
- `feature/giveaways/.../GiveawaysScreen.kt`: replace `.toMutableList().map { ... }` with `.map { ... }.toImmutableList()` so the field stays typed as `ImmutableList` after a chip toggle.
- `domain/build.gradle.kts`: add `libs.kotlinx.collections.immutable` (already in the catalog from PR #70).
- Tests: switch the `GiveawaySearchParameters(...)` constructions in `GiveawaysRepositoryTest` and `GiveawaysViewModelTest` from `listOf(...)` to `persistentListOf(...)`.

## Test plan

- [x] `./gradlew :domain:testDebugUnitTest` — passes
- [x] `./gradlew :feature:giveaways:testDebugUnitTest` — passes

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>