### PR TITLE
fix(#80): annotate GameDetails @Immutable + migrate deals to ImmutableList

### DIFF
--- a/common/ui/build.gradle.kts
+++ b/common/ui/build.gradle.kts
@@ -15,6 +15,7 @@ dependencies {
     implementation(libs.androidx.ktx)
     implementation(libs.androidx.appcompat)
     implementation(libs.material)
+    implementation(libs.kotlinx.collections.immutable)
     implementation(libs.androidx.compose.activity)
     implementation(libs.androidx.compose.navigation)
     implementation(libs.androidx.compose.runtime)

--- a/common/ui/src/main/java/pm/bam/gamedeals/common/ui/PreviewData.kt
+++ b/common/ui/src/main/java/pm/bam/gamedeals/common/ui/PreviewData.kt
@@ -1,5 +1,6 @@
 package pm.bam.gamedeals.common.ui
 
+import kotlinx.collections.immutable.persistentListOf
 import pm.bam.gamedeals.domain.models.Deal
 import pm.bam.gamedeals.domain.models.DealDetails
 import pm.bam.gamedeals.domain.models.Game
@@ -26,6 +27,6 @@ val PreviewDealDetails = DealDetails(PreviewDealGameInfo, listOf(PreviewDealChea
 val PreviewGameDetailsInfo = GameDetails.GameInfo(title = "Game Title", steamAppID = null, thumb = "Thumb")
 val PreviewGameCheapestPriceEver = GameDetails.GameCheapestPriceEver(19.99, "$19.99", date = "January 13, 2011")
 val PreviewGameDeal = GameDetails.GameDeal(1, "123", 9.99, "$9.99", 29.99, "$29.99", 90)
-val PreviewGameDetails = GameDetails(PreviewGameDetailsInfo, PreviewGameCheapestPriceEver, listOf(PreviewGameDeal))
+val PreviewGameDetails = GameDetails(PreviewGameDetailsInfo, PreviewGameCheapestPriceEver, persistentListOf(PreviewGameDeal))
 
 val PreviewGame = Game(1, 123, 7.49, "$7.49", "123", "Game Tile", "Game Internal Title", "Thumb")

--- a/domain/src/main/java/pm/bam/gamedeals/domain/models/Game.kt
+++ b/domain/src/main/java/pm/bam/gamedeals/domain/models/Game.kt
@@ -1,8 +1,10 @@
 package pm.bam.gamedeals.domain.models
 
 
+import androidx.compose.runtime.Immutable
 import androidx.room.Entity
 import androidx.room.PrimaryKey
+import kotlinx.collections.immutable.ImmutableList
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
@@ -28,6 +30,7 @@ data class Game(
     val thumb: String
 )
 
+@Immutable
 @Serializable
 data class GameDetails(
     @SerialName("info")
@@ -35,7 +38,7 @@ data class GameDetails(
     @SerialName("cheapestPriceEver")
     val cheapestPriceEver: GameCheapestPriceEver,
     @SerialName("deals")
-    val deals: List<GameDeal>
+    val deals: ImmutableList<GameDeal>
 ) {
     @Serializable
     data class GameInfo(

--- a/feature/game/src/androidTest/java/pm/bam/gamedeals/feature/game/ui/GameScreenTest.kt
+++ b/feature/game/src/androidTest/java/pm/bam/gamedeals/feature/game/ui/GameScreenTest.kt
@@ -61,7 +61,7 @@ class GameScreenTest {
     }
     private val gameDetails: GameDetails = mockk {
         every { info } returns gameInfo
-        every { deals } returns listOf(gameDeal)
+        every { deals } returns persistentListOf(gameDeal)
         every { cheapestPriceEver } returns mockCheapestPriceEver
     }
 

--- a/feature/game/src/test/java/pm/bam/gamedeals/feature/game/ui/GameViewModelTest.kt
+++ b/feature/game/src/test/java/pm/bam/gamedeals/feature/game/ui/GameViewModelTest.kt
@@ -78,7 +78,7 @@ class GameViewModelTest {
         val storeId = 2
         val store: Store = mockk()
         val gameDeals: GameDetails.GameDeal = mockk { every { storeID } returns storeId }
-        val dealsList = listOf(gameDeals)
+        val dealsList = persistentListOf(gameDeals)
         val gameDetails: GameDetails = mockk { every { deals } returns dealsList }
 
         coEvery { gamesRepository.getGameDetails(gameId) } returns gameDetails
@@ -104,7 +104,7 @@ class GameViewModelTest {
         val storeId = 2
         val store: Store = mockk()
         val gameDeals: GameDetails.GameDeal = mockk { every { storeID } returns storeId }
-        val dealsList = listOf(gameDeals)
+        val dealsList = persistentListOf(gameDeals)
         val gameDetails: GameDetails = mockk { every { deals } returns dealsList }
 
         coEvery { gamesRepository.getGameDetails(gameId) } returns gameDetails

--- a/remote/cheapshark/build.gradle.kts
+++ b/remote/cheapshark/build.gradle.kts
@@ -23,6 +23,7 @@ dependencies {
     implementation(libs.material)
 
     implementation(libs.coroutines)
+    implementation(libs.kotlinx.collections.immutable)
 
     implementation(libs.hilt.android)
     ksp(libs.hilt.compiler)

--- a/remote/cheapshark/src/main/java/pm/bam/gamedeals/remote/cheapshark/mappers/GameMappers.kt
+++ b/remote/cheapshark/src/main/java/pm/bam/gamedeals/remote/cheapshark/mappers/GameMappers.kt
@@ -1,5 +1,6 @@
 package pm.bam.gamedeals.remote.cheapshark.mappers
 
+import kotlinx.collections.immutable.toImmutableList
 import pm.bam.gamedeals.common.datetime.formatting.DateTimeFormatter
 import pm.bam.gamedeals.domain.models.Game
 import pm.bam.gamedeals.domain.models.GameDetails
@@ -59,5 +60,5 @@ internal fun RemoteGameDetails.toGameDetails(
     GameDetails(
         info = info.toGameInfo(),
         cheapestPriceEver = cheapestPriceEver.toGameCheapestPriceEver(currencyTransformation, datetimeFormatter),
-        deals = deals.map { it.toGameDeal(currencyTransformation) },
+        deals = deals.map { it.toGameDeal(currencyTransformation) }.toImmutableList(),
     )


### PR DESCRIPTION
Closes #80.

## Summary
- Annotate `GameDetails` with `@Immutable` and retype `deals` from `List<GameDeal>` to `kotlinx.collections.immutable.ImmutableList<GameDeal>` so `CompactGameDetail` / `WideGameDetail` can skip when their parent recomposes with the same value. The annotation advertises stability for Compose skipping; the type provides the type-system guarantee.
- Update the `RemoteGameDetails` to `GameDetails` mapper to finish the deals chain with `.toImmutableList()` so the field stays typed as `ImmutableList`.
- Convert `PreviewData.PreviewGameDetails` and the `GameViewModel` / `GameScreen` tests that mock or construct `GameDetails` to `persistentListOf`.
- Add `kotlinx.collections.immutable` to `:common:ui` and `:remote:cheapshark`, which now reference the type directly.

Mirrors the pattern from PR #82 (issue #79) which just merged: `@Immutable` annotation + `ImmutableList` field type, with the mapper performing the `.toImmutableList()` conversion.

## Test plan
- [x] `:domain:testDebugUnitTest`
- [x] `:remote:cheapshark:testDebugUnitTest`
- [x] `:common:ui:testDebugUnitTest`
- [x] `:feature:game:testDebugUnitTest`
- [x] `:app:assembleDebug` (sanity check that all modules still compile)

Generated with [Claude Code](https://claude.com/claude-code)