### PR TITLE
fix(#71): rethrow CancellationException in DealDetailsController.load

### DIFF
--- a/common/ui/src/main/java/pm/bam/gamedeals/common/ui/deal/DealDetailsController.kt
+++ b/common/ui/src/main/java/pm/bam/gamedeals/common/ui/deal/DealDetailsController.kt
@@ -1,5 +1,6 @@
 package pm.bam.gamedeals.common.ui.deal
 
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -52,6 +53,8 @@ class DealDetailsController(
                 )
             }
             _dealDetails.emit(data)
+        } catch (t: CancellationException) {
+            throw t
         } catch (t: Throwable) {
             fatal(logger, t)
             try {
@@ -63,6 +66,8 @@ class DealDetailsController(
                         gameSalesPriceDenominated = dealPriceDenominated,
                     )
                 )
+            } catch (inner: CancellationException) {
+                throw inner
             } catch (inner: Throwable) {
                 fatal(logger, inner)
                 _dealDetails.emit(null)


### PR DESCRIPTION
Closes #71.

## Summary
`DealDetailsController.load(...)` wrapped its work in `try { ... } catch (t: Throwable) { ... }` at both the outer site and the inner fallback emit, neither of which rethrew `CancellationException`. When the host scope was cancelled mid-load (config change, navigation, sheet dismissal), the cancellation was logged as a fatal Crashlytics error and the bottom-sheet state was overwritten with `DealDetailsError` or `null` instead of cancellation propagating cleanly.

This change adds a `catch (CancellationException) { throw it }` clause before each `catch (Throwable)` block, mirroring the structured-concurrency pattern already in `DealsMediator.kt`.

## Test plan
- [x] `:common:ui:compileDebugKotlin` (Android Studio JBR 21) succeeds
- [x] `:common:ui:testDebugUnitTest` runs (no unit tests in module — `NO-SOURCE`)
- [ ] Manual: open and quickly dismiss a deal bottom sheet — no fatal log; no stale error state

🤖 Generated with [Claude Code](https://claude.com/claude-code)