### PR TITLE
fix(#74): wrap SingleEventEffect collector in rememberUpdatedState

### DIFF
--- a/common/src/main/java/pm/bam/gamedeals/common/CommonFlowExtensions.kt
+++ b/common/src/main/java/pm/bam/gamedeals/common/CommonFlowExtensions.kt
@@ -2,6 +2,8 @@ package pm.bam.gamedeals.common
 
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.rememberUpdatedState
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.lifecycle.repeatOnLifecycle
@@ -72,6 +74,10 @@ inline fun <reified T> Flow<T>.retryOnException(
  * Note that because the provided [sideEffectFlow] itself is being used as the key for the [LaunchedEffect],
  * repeating the same data ***will*** trigger the [collector] again.
  *
+ * The [collector] lambda is wrapped via [rememberUpdatedState], so callers may safely close over
+ * screen-local state (navigation controllers, analytics payloads, etc.) without observing a
+ * stale capture from the first composition.
+ *
  * @param sideEffectFlow The flow of side effects to collect.
  * @param lifeCycleState The lifecycle state to collect the side effects in. Default is [Lifecycle.State.STARTED].
  * @param collector The collector to handle the side effects.
@@ -83,10 +89,11 @@ fun <T : Any> SingleEventEffect(
     collector: suspend (T) -> Unit
 ) {
     val lifecycleOwner = LocalLifecycleOwner.current
+    val currentCollector by rememberUpdatedState(collector)
 
-    LaunchedEffect(sideEffectFlow) {
+    LaunchedEffect(sideEffectFlow, lifecycleOwner, lifeCycleState) {
         lifecycleOwner.repeatOnLifecycle(lifeCycleState) {
-            sideEffectFlow.collect(collector)
+            sideEffectFlow.collect { currentCollector(it) }
         }
     }
 }


### PR DESCRIPTION
Closes #74.

## Summary
`SingleEventEffect` keyed its `LaunchedEffect` only on `sideEffectFlow` and captured the `collector` lambda directly, so callers whose `collector` closed over screen-local state would silently fire stale callbacks across recompositions. This wraps the lambda in `rememberUpdatedState` so the latest reference is always invoked, and adds `lifecycleOwner` / `lifeCycleState` as `LaunchedEffect` keys so collection restarts if either changes. KDoc updated to document the safety guarantee.

## Test plan
- [x] `:common:compileDebugKotlin`
- [x] `:common:testDebugUnitTest`
- [x] `:feature:home:compileDebugKotlin` (only existing call site)

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>

Generated with [Claude Code](https://claude.com/claude-code)