### PR TITLE
fix(#72): drive GiveawaysViewModel via flatMapLatest on parametersFlow

### DIFF
--- a/feature/giveaways/src/main/java/pm/bam/gamedeals/feature/giveaways/ui/GiveawaysViewModel.kt
+++ b/feature/giveaways/src/main/java/pm/bam/gamedeals/feature/giveaways/ui/GiveawaysViewModel.kt
@@ -7,11 +7,13 @@ import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.persistentListOf
 import kotlinx.collections.immutable.toImmutableList
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.emitAll
+import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.update
@@ -24,6 +26,7 @@ import pm.bam.gamedeals.logging.Logger
 import javax.inject.Inject
 
 
+@OptIn(ExperimentalCoroutinesApi::class)
 @HiltViewModel
 internal class GiveawaysViewModel @Inject constructor(
     private val logger: Logger,
@@ -33,10 +36,16 @@ internal class GiveawaysViewModel @Inject constructor(
     private val _uiState = MutableStateFlow(GiveawaysScreenData())
     val uiState: StateFlow<GiveawaysScreenData> = _uiState.asStateFlow()
 
+    private val parametersFlow = MutableStateFlow<GiveawaySearchParameters?>(null)
+
 
     init {
         viewModelScope.launch {
-            flow { emitAll(giveawaysRepository.observeGiveaways()) }
+            parametersFlow
+                .flatMapLatest { params ->
+                    if (params == null) flow { emitAll(giveawaysRepository.observeGiveaways()) }
+                    else flow { emitAll(giveawaysRepository.observeGiveaways(params)) }
+                }
                 .map { GiveawaysScreenData(status = GiveawaysScreenStatus.SUCCESS, giveaways = it.toImmutableList()) }
                 .logFlow(logger)
                 .catch { _uiState.update { current -> current.copy(status = GiveawaysScreenStatus.ERROR) } }
@@ -57,13 +66,7 @@ internal class GiveawaysViewModel @Inject constructor(
     }
 
     fun loadGiveaway(parameters: GiveawaySearchParameters) {
-        viewModelScope.launch {
-            flow { emitAll(giveawaysRepository.observeGiveaways(parameters)) }
-                .map { GiveawaysScreenData(status = GiveawaysScreenStatus.SUCCESS, giveaways = it.toImmutableList()) }
-                .logFlow(logger)
-                .catch { _uiState.update { current -> current.copy(status = GiveawaysScreenStatus.ERROR) } }
-                .collect { newState -> _uiState.emit(newState) }
-        }
+        parametersFlow.value = parameters
     }
 
 

--- a/feature/giveaways/src/test/java/pm/bam/gamedeals/feature/giveaways/ui/GiveawaysViewModelTest.kt
+++ b/feature/giveaways/src/test/java/pm/bam/gamedeals/feature/giveaways/ui/GiveawaysViewModelTest.kt
@@ -7,6 +7,7 @@ import io.mockk.runs
 import kotlinx.collections.immutable.persistentListOf
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.runTest
@@ -111,6 +112,44 @@ class GiveawaysViewModelTest {
         Assert.assertEquals(2, emissions.first().giveaways.size)
         Assert.assertEquals(resultThree, emissions.first().giveaways.first())
         Assert.assertEquals(resultOne, emissions.first().giveaways.second())
+    }
+
+    @Test
+    fun `load Giveaways cancels prior unfiltered collector when filter applied`() = runTest {
+        val unfilteredOne = mockk<Giveaway>()
+        val unfilteredTwo = mockk<Giveaway>()
+        val filteredOne = mockk<Giveaway>()
+
+        val para = GiveawaySearchParameters(
+            types = persistentListOf(GiveawayType.GAME to true),
+            platforms = persistentListOf(GiveawayPlatform.PC to true),
+            sortBy = GiveawaySortBy.DATE
+        )
+
+        // Model the hot Room Flows: each invalidation re-emits, the flow never completes.
+        val unfilteredRoom = MutableSharedFlow<List<Giveaway>>(replay = 1)
+        val filteredRoom = MutableSharedFlow<List<Giveaway>>(replay = 1)
+        coEvery { giveawaysRepository.observeGiveaways() } returns unfilteredRoom
+        coEvery { giveawaysRepository.observeGiveaways(any()) } returns filteredRoom
+
+        val viewModel = GiveawaysViewModel(TestingLoggingListener(), giveawaysRepository)
+
+        // Initial unfiltered emission seeds the screen with two giveaways.
+        unfilteredRoom.emit(listOf(unfilteredOne, unfilteredTwo))
+
+        // User applies a filter; the active source must switch to the filtered Room flow.
+        viewModel.loadGiveaway(para)
+        filteredRoom.emit(listOf(filteredOne))
+
+        // Simulate a Room invalidation re-emitting on the unfiltered flow (e.g. after refreshGiveaways).
+        // With parallel collectors this would clobber the filtered result; with flatMapLatest the
+        // unfiltered collector is cancelled and this emission is ignored.
+        unfilteredRoom.emit(listOf(unfilteredOne, unfilteredTwo))
+
+        val emissions = observeStates(viewModel)
+        Assert.assertEquals(GiveawaysViewModel.GiveawaysScreenStatus.SUCCESS, emissions.last().status)
+        Assert.assertEquals(1, emissions.last().giveaways.size)
+        Assert.assertEquals(filteredOne, emissions.last().giveaways.first())
     }
 
 


### PR DESCRIPTION
Closes #72.

## Summary
- The `init` block launched a long-lived collector on `giveawaysRepository.observeGiveaways()` (hot Room Flow). Each call to `loadGiveaway(parameters)` launched a *second* collector on `observeGiveaways(parameters)` without cancelling the prior one, so both stayed active in `viewModelScope` and concurrently wrote `_uiState` on every Room invalidation. The UI flipped between filtered and unfiltered results whenever the `giveaways` table changed (e.g. after `refreshGiveaways`).
- Drive the source from a `MutableStateFlow<GiveawaySearchParameters?>` and `flatMapLatest` into the Room flow. `loadGiveaway` now just updates `parametersFlow.value`; the single init-time collector switches sources transparently and the prior inner subscription is cancelled automatically.
- Preserve the project's `flow { emitAll(repo.observeXxx()) }` convention (lessons L-2026-04-30-04 / L-2026-04-30-05) so synchronous construction-time throws from the repository still surface to the downstream `.catch`.

## Test plan
- [x] `:feature:giveaways:testDebugUnitTest` — all existing tests pass with the new flow shape
- [x] Added regression test `load Giveaways cancels prior unfiltered collector when filter applied` — models hot Room flows with `MutableSharedFlow` and asserts that a post-filter unfiltered re-emission no longer clobbers the filtered result (this test would fail against the buggy parallel-collector code)
- [x] `:feature:giveaways:lintDebug` clean
- [x] `:feature:giveaways:assembleDebug` builds

🤖 Generated with [Claude Code](https://claude.com/claude-code)