### PR TITLE
fix(#73): drive GameViewModel reload via reloadTrigger combined into source flow

### DIFF
--- a/feature/game/src/main/java/pm/bam/gamedeals/feature/game/ui/GameViewModel.kt
+++ b/feature/game/src/main/java/pm/bam/gamedeals/feature/game/ui/GameViewModel.kt
@@ -8,10 +8,13 @@ import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.toImmutableList
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.channels.BufferOverflow
+import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.catch
+import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.filterNotNull
 import kotlinx.coroutines.flow.flatMapLatest
@@ -46,11 +49,20 @@ internal class GameViewModel @Inject constructor(
     private val _uiState = MutableStateFlow<GameScreenData>(GameScreenData.Loading)
     val uiState: StateFlow<GameScreenData> = _uiState.asStateFlow()
 
+    private val reloadTrigger = MutableSharedFlow<Unit>(
+        replay = 0,
+        extraBufferCapacity = 1,
+        onBufferOverflow = BufferOverflow.DROP_OLDEST
+    )
+
     init {
         viewModelScope.launch {
-            gameIdFlow
-                .filterNotNull() // Skip our initial null value
-                .distinctUntilChanged() // Skip fetching if storeId is the same, like on orientation change
+            combine(
+                gameIdFlow
+                    .filterNotNull() // Skip our initial null value
+                    .distinctUntilChanged(), // Skip fetching if gameId is the same, like on orientation change
+                reloadTrigger.onStart { emit(Unit) },
+            ) { id, _ -> id }
                 .delayOnStart(1000)
                 .flatMapLatest { loadGameDetailsFlow(it) }
                 .logFlow(logger)
@@ -60,11 +72,7 @@ internal class GameViewModel @Inject constructor(
 
 
     fun reloadGameDetails() {
-        val gameId = gameIdFlow.value ?: return
-        viewModelScope.launch {
-            loadGameDetailsFlow(gameId)
-                .collect { _uiState.emit(it) }
-        }
+        reloadTrigger.tryEmit(Unit)
     }
 
     private fun loadGameDetailsFlow(gameId: Int) =

--- a/feature/game/src/test/java/pm/bam/gamedeals/feature/game/ui/GameViewModelTest.kt
+++ b/feature/game/src/test/java/pm/bam/gamedeals/feature/game/ui/GameViewModelTest.kt
@@ -17,8 +17,10 @@ import pm.bam.gamedeals.domain.repositories.games.GamesRepository
 import pm.bam.gamedeals.domain.repositories.stores.StoresRepository
 import pm.bam.gamedeals.testing.MainCoroutineRule
 import pm.bam.gamedeals.testing.TestingLoggingListener
+import pm.bam.gamedeals.testing.utils.fourth
 import pm.bam.gamedeals.testing.utils.observeEmissions
 import pm.bam.gamedeals.testing.utils.second
+import pm.bam.gamedeals.testing.utils.third
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class GameViewModelTest {
@@ -116,10 +118,15 @@ class GameViewModelTest {
         assertEquals(1, emissions.size)
         assertEquals(GameViewModel.GameScreenData.Loading, emissions.first())
 
-        viewModel.reloadGameDetails()
+        delay(1200) // Initial load completes after delayOnStart.
 
         assertEquals(2, emissions.size)
-        assertEquals(GameViewModel.GameScreenData.Loading, emissions.first())
         assertEquals(GameViewModel.GameScreenData.Data(gameDetails, persistentListOf(store to gameDeals)), emissions.second())
+
+        viewModel.reloadGameDetails()
+
+        assertEquals(4, emissions.size)
+        assertEquals(GameViewModel.GameScreenData.Loading, emissions.third())
+        assertEquals(GameViewModel.GameScreenData.Data(gameDetails, persistentListOf(store to gameDeals)), emissions.fourth())
     }
 }


### PR DESCRIPTION
Closes #73.

## Summary
- Each `reloadGameDetails()` call previously launched a *new* `viewModelScope.launch { loadGameDetailsFlow(gameId).collect { _uiState.emit(it) } }`. The original `init { ... flatMapLatest { loadGameDetailsFlow(it) } ... }` collector kept running in parallel, so repeated retry taps stacked collectors and concurrent emissions raced onto `_uiState`.
- Replace the parallel launch with a `MutableSharedFlow<Unit>` (`reloadTrigger`) that is `combine`d with `gameIdFlow` upstream of the existing `flatMapLatest` collector. Reloads now flow through the same source-of-truth pipeline, so `flatMapLatest` cancels any in-flight load before starting the next one — no orphan jobs, no late-arrival clobbering.
- Preserves the project's Flow-shaped handler convention (L-2026-04-30-04); no `Job?` cancellation bookkeeping needed. Public API of the ViewModel is unchanged.
- Same antipattern was previously fixed in `HomeViewModel` (issue #33).

## Test plan
- [x] `:feature:game:testDebugUnitTest` — `GameViewModelTest` (`initially loading state`, `error state`, `game load`, `game reload`) all pass. The `game reload` test was extended to also cover the post-initial-load reload path; the previous assertion only worked because the parallel-launch bug bypassed `delayOnStart`.
- [x] `:feature:game:lintDebug` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)