### PR TITLE
fix(#76): restore SearchParameters data-class equals; fix StateFlow conflation in SearchViewModel

### DIFF
--- a/domain/src/main/java/pm/bam/gamedeals/domain/models/Search.kt
+++ b/domain/src/main/java/pm/bam/gamedeals/domain/models/Search.kt
@@ -44,12 +44,6 @@ data class SearchParameters(
             map.mapNotNull { (key, value) -> value?.let { key to it } }
                 .toMap())
     }
-
-    /**
-     * Returning `false` to avoid the default implementation of `equals` when attempting to emit a new value in a `StateFlow`.
-     * See "Strong equality-based conflation" in the StateFlow documentation.
-     */
-    override fun equals(other: Any?): Boolean = false
 }
 
 enum class DealsSortBy {

--- a/feature/search/src/main/java/pm/bam/gamedeals/feature/search/ui/SearchViewModel.kt
+++ b/feature/search/src/main/java/pm/bam/gamedeals/feature/search/ui/SearchViewModel.kt
@@ -7,6 +7,8 @@ import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.toImmutableList
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.channels.BufferOverflow
+import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -34,7 +36,10 @@ internal class SearchViewModel @Inject constructor(
 ) : ViewModel() {
 
     // We store and react to the Query changes so that only a single search flow can exists
-    private val searchParametersFlow = MutableStateFlow<SearchParameters?>(null)
+    private val searchParametersFlow = MutableSharedFlow<SearchParameters?>(
+        replay = 1,
+        onBufferOverflow = BufferOverflow.DROP_OLDEST
+    )
 
     private val _resultState = MutableStateFlow<SearchData>(SearchData.Empty)
     val resultState: StateFlow<SearchData> = _resultState.asStateFlow()


### PR DESCRIPTION
Closes #76.

## Summary
- `SearchParameters` overrode `equals` to unconditionally return `false` so that successive emissions of structurally identical values would not be conflated by the upstream `MutableStateFlow` in `SearchViewModel`. That hack defeated Compose stability/skipping: every `SearchScreen` recomposition forced `Screen` -> `SearchFilters` -> `Filters` to recompose because the parameter comparison always failed.
- Removed the `equals` override, restoring proper data-class equals (all fields are scalar/nullable primitives and an enum, so the class is naturally Compose-stable).
- Moved the de-conflation responsibility to the flow boundary: `searchParametersFlow` is now a `MutableSharedFlow<SearchParameters?>(replay = 1, onBufferOverflow = DROP_OLDEST)` so identical successive values still trigger the downstream `flatMapLatest` re-search without leaning on broken value semantics.

## Test plan
- [x] `:feature:search:testDebugUnitTest` (existing `SearchViewModelTest` passes unchanged)
- [x] `:domain:testDebugUnitTest`
- [x] `:app:assembleDebug`

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>

Generated with [Claude Code](https://claude.com/claude-code)