### PR TITLE
fix(#75, #77): preserve refresh ERROR across Room invalidations

### DIFF
--- a/feature/giveaways/src/main/java/pm/bam/gamedeals/feature/giveaways/ui/GiveawaysViewModel.kt
+++ b/feature/giveaways/src/main/java/pm/bam/gamedeals/feature/giveaways/ui/GiveawaysViewModel.kt
@@ -12,10 +12,10 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.catch
+import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.emitAll
 import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.flow
-import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import pm.bam.gamedeals.common.logFlow
@@ -37,16 +37,29 @@ internal class GiveawaysViewModel @Inject constructor(
     val uiState: StateFlow<GiveawaysScreenData> = _uiState.asStateFlow()
 
     private val parametersFlow = MutableStateFlow<GiveawaySearchParameters?>(null)
+    private val refreshOutcomeFlow = MutableStateFlow<RefreshOutcome>(RefreshOutcome.Idle)
 
 
     init {
         viewModelScope.launch {
-            parametersFlow
+            val giveawaysFlow = parametersFlow
                 .flatMapLatest { params ->
                     if (params == null) flow { emitAll(giveawaysRepository.observeGiveaways()) }
                     else flow { emitAll(giveawaysRepository.observeGiveaways(params)) }
                 }
-                .map { GiveawaysScreenData(status = GiveawaysScreenStatus.SUCCESS, giveaways = it.toImmutableList()) }
+
+            combine(giveawaysFlow, refreshOutcomeFlow) { giveaways, outcome ->
+                when (outcome) {
+                    is RefreshOutcome.Error -> GiveawaysScreenData(
+                        status = GiveawaysScreenStatus.ERROR,
+                        giveaways = giveaways.toImmutableList()
+                    )
+                    RefreshOutcome.Idle -> GiveawaysScreenData(
+                        status = GiveawaysScreenStatus.SUCCESS,
+                        giveaways = giveaways.toImmutableList()
+                    )
+                }
+            }
                 .logFlow(logger)
                 .catch { _uiState.update { current -> current.copy(status = GiveawaysScreenStatus.ERROR) } }
                 .collect { newState -> _uiState.emit(newState) }
@@ -56,11 +69,12 @@ internal class GiveawaysViewModel @Inject constructor(
     fun reloadGiveaways() {
         viewModelScope.launch {
             flow<Unit> {
+                refreshOutcomeFlow.value = RefreshOutcome.Idle
                 _uiState.update { current -> current.copy(status = GiveawaysScreenStatus.LOADING) }
                 giveawaysRepository.refreshGiveaways()
             }
                 .logFlow(logger)
-                .catch { _uiState.update { current -> current.copy(status = GiveawaysScreenStatus.ERROR) } }
+                .catch { refreshOutcomeFlow.value = RefreshOutcome.Error }
                 .collect { }
         }
     }
@@ -79,5 +93,10 @@ internal class GiveawaysViewModel @Inject constructor(
 
     internal enum class GiveawaysScreenStatus {
         LOADING, ERROR, SUCCESS
+    }
+
+    private sealed interface RefreshOutcome {
+        data object Idle : RefreshOutcome
+        data object Error : RefreshOutcome
     }
 }

--- a/feature/giveaways/src/test/java/pm/bam/gamedeals/feature/giveaways/ui/GiveawaysViewModelTest.kt
+++ b/feature/giveaways/src/test/java/pm/bam/gamedeals/feature/giveaways/ui/GiveawaysViewModelTest.kt
@@ -115,6 +115,70 @@ class GiveawaysViewModelTest {
     }
 
     @Test
+    fun `failed reload sets ERROR`() = runTest {
+        val unfilteredRoom = MutableSharedFlow<List<Giveaway>>(replay = 1)
+        coEvery { giveawaysRepository.observeGiveaways() } returns unfilteredRoom
+        coEvery { giveawaysRepository.refreshGiveaways() } throws Exception()
+
+        val viewModel = GiveawaysViewModel(TestingLoggingListener(), giveawaysRepository)
+        unfilteredRoom.emit(emptyList())
+
+        viewModel.reloadGiveaways()
+
+        val emissions = observeStates(viewModel)
+        Assert.assertEquals(GiveawaysViewModel.GiveawaysScreenStatus.ERROR, emissions.last().status)
+    }
+
+    @Test
+    fun `ERROR from failed reload survives subsequent Room invalidation`() = runTest {
+        val giveaway = mockk<Giveaway>()
+        val unfilteredRoom = MutableSharedFlow<List<Giveaway>>(replay = 1)
+        coEvery { giveawaysRepository.observeGiveaways() } returns unfilteredRoom
+        coEvery { giveawaysRepository.refreshGiveaways() } throws Exception()
+
+        val viewModel = GiveawaysViewModel(TestingLoggingListener(), giveawaysRepository)
+        unfilteredRoom.emit(emptyList())
+
+        viewModel.reloadGiveaways()
+
+        // Simulate a Room invalidation arriving after the refresh has already failed.
+        unfilteredRoom.emit(listOf(giveaway))
+
+        val emissions = observeStates(viewModel)
+        Assert.assertEquals(GiveawaysViewModel.GiveawaysScreenStatus.ERROR, emissions.last().status)
+    }
+
+    @Test
+    fun `successful reload after a failure flips ERROR back to SUCCESS`() = runTest {
+        val giveaway = mockk<Giveaway>()
+        val unfilteredRoom = MutableSharedFlow<List<Giveaway>>(replay = 1)
+        coEvery { giveawaysRepository.observeGiveaways() } returns unfilteredRoom
+        var refreshCallCount = 0
+        coEvery { giveawaysRepository.refreshGiveaways() } coAnswers {
+            refreshCallCount++
+            if (refreshCallCount == 1) throw Exception()
+        }
+
+        val viewModel = GiveawaysViewModel(TestingLoggingListener(), giveawaysRepository)
+        unfilteredRoom.emit(emptyList())
+
+        viewModel.reloadGiveaways()
+        // Pre-condition: first refresh failed → ERROR.
+        Assert.assertEquals(
+            GiveawaysViewModel.GiveawaysScreenStatus.ERROR,
+            observeStates(viewModel).last().status
+        )
+
+        viewModel.reloadGiveaways()
+        // The successful refresh write triggers a Room invalidation in production; model it here.
+        unfilteredRoom.emit(listOf(giveaway))
+
+        val emissions = observeStates(viewModel)
+        Assert.assertEquals(GiveawaysViewModel.GiveawaysScreenStatus.SUCCESS, emissions.last().status)
+        Assert.assertEquals(1, emissions.last().giveaways.size)
+    }
+
+    @Test
     fun `load Giveaways cancels prior unfiltered collector when filter applied`() = runTest {
         val unfilteredOne = mockk<Giveaway>()
         val unfilteredTwo = mockk<Giveaway>()


### PR DESCRIPTION
Closes #75. Closes #77.

## Summary

After PR #86, `GiveawaysViewModel`'s init collector was a single source-of-truth on `parametersFlow.flatMapLatest { observeGiveaways(...) }` that mapped every Room emission to `SUCCESS`. That left two bugs:

- A failed `reloadGiveaways()` set `ERROR` via its own `.catch`, but the next Room invalidation overwrote it back to `SUCCESS` (#75).
- The `reloadGiveaways()` flow had no `SUCCESS` of its own — recovery was implicit on Room invalidation, with no way to express "refresh failed, keep showing ERROR" in the unified screen state (#77).

## Architecture

- New `private sealed interface RefreshOutcome { Idle, Error }` backed by a `MutableStateFlow<RefreshOutcome>(Idle)`.
- The source-of-truth flow now `combine`s the giveaways flow with `refreshOutcomeFlow`. The mapper resolves to `ERROR` when outcome is `Error`, else `SUCCESS` — so ERROR persists across Room invalidations until the user retries.
- `reloadGiveaways()` resets the outcome to `Idle` first, then sets `LOADING`, then calls `refreshGiveaways()`. Its `.catch` flips the outcome to `Error`, which the combine collector observes and pushes to `_uiState`.
- `loadGiveaway(parameters)` continues to drive `parametersFlow`; the init collector stays subscribed via `flatMapLatest`.

## Test plan

- [x] `failed reload sets ERROR` — `refreshGiveaways()` throws → screen ends in ERROR.
- [x] `ERROR from failed reload survives subsequent Room invalidation` — after the failed refresh, a Room re-emission does not flip ERROR back to SUCCESS.
- [x] `successful reload after a failure flips ERROR back to SUCCESS` — second `reloadGiveaways()` resets the outcome and the next Room emission is mapped to SUCCESS.
- [x] All pre-existing tests still pass: filter change via `loadGiveaway(parameters)`, LOADING-before-refresh-completes, initial load/error, and the parallel-collector cancellation test from PR #86.
- [x] `:feature:giveaways:lintDebug` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)