### PR TITLE
fix(#91): replace wall-clock padding in withMinimumDuration

### DIFF
--- a/common/src/main/java/pm/bam/gamedeals/common/FlowExtensions.kt
+++ b/common/src/main/java/pm/bam/gamedeals/common/FlowExtensions.kt
@@ -90,16 +90,20 @@ fun <T, R> Flow<T>.mapDelayAtLeast(delayMillis: Long, transformFunction: suspend
 
 
 /**
- * Runs [block] and ensures the total elapsed wall-clock time is at least [delayMillis] before
- * returning the result. If [block] completes faster than [delayMillis], suspends for the remainder.
+ * Runs [block] and ensures the total elapsed time is at least [delayMillis] before returning the
+ * result. If [block] completes faster than [delayMillis], suspends for the remainder.
  *
  * Useful for "minimum loading duration" UX where you want to avoid flashing a loading state too briefly.
+ *
+ * Implementation runs [block] and the [delay] concurrently inside a [coroutineScope] so the elapsed
+ * time is measured by the coroutine's own clock. This makes the function behave identically in
+ * production and under `runTest` with a `TestDispatcher`'s virtual time, instead of relying on
+ * `System.currentTimeMillis()` (which ignores the test's virtual clock).
  */
 suspend inline fun <T> withMinimumDuration(delayMillis: Long, crossinline block: suspend () -> T): T = coroutineScope {
-    val before = System.currentTimeMillis()
+    val pad = launch { delay(delayMillis) }
     val result = block()
-    val elapsed = System.currentTimeMillis() - before
-    if (elapsed < delayMillis) delay(delayMillis - elapsed)
+    pad.join()
     result
 }
 

--- a/common/src/test/java/pm/bam/gamedeals/common/FlowExtensionsTest.kt
+++ b/common/src/test/java/pm/bam/gamedeals/common/FlowExtensionsTest.kt
@@ -90,6 +90,29 @@ class FlowExtensionsTest {
     }
 
     @Test
+    fun `withMinimumDuration pads to delayMillis when block is instant`() = runTest {
+        val start = testScheduler.currentTime
+        val result = withMinimumDuration(DELAY_MILLIS) { 21 * 2 }
+        val elapsed = testScheduler.currentTime - start
+
+        assertEquals(42, result)
+        assertEquals(DELAY_MILLIS, elapsed)
+    }
+
+    @Test
+    fun `withMinimumDuration does not pad when block takes longer than delayMillis`() = runTest {
+        val start = testScheduler.currentTime
+        val result = withMinimumDuration(DELAY_MILLIS) {
+            delay(LONG_WORK_MILLIS)
+            21 * 2
+        }
+        val elapsed = testScheduler.currentTime - start
+
+        assertEquals(42, result)
+        assertEquals(LONG_WORK_MILLIS, elapsed)
+    }
+
+    @Test
     fun `latestDelayAtLeast cancels pending pad when a new value arrives`() = runTest {
         // Emits 1 immediately, then 2 after `delayMillis * 2`. Because
         // `latestDelayAtLeast` uses `transformLatest`, the in-flight pad for


### PR DESCRIPTION
Closes #91.

`withMinimumDuration` was measuring elapsed time with `System.currentTimeMillis()` and padding via `delay(...)` for the remainder. Under `runTest` with a `TestDispatcher` virtual clock, the measured elapsed is always ~0, so the function pads against wall-clock instead of advancing virtual time — any test exercising `DealDetailsController.load` blocks for a real 750 ms.

This is the missing companion to #45 / PR #59, which already applied the same launched-pad pattern to `mapDelayAtLeast` and `flatMapLatestDelayAtLeast`. `withMinimumDuration` was overlooked in that pass. The fix mirrors the same approach: run `block()` and a `launch { delay(delayMillis) }` concurrently inside `coroutineScope`, so the time is measured by the coroutine's own clock and the operator behaves identically in production and under `runTest`. `inline` and `crossinline` semantics are preserved.

## Tests
Added two test cases to `FlowExtensionsTest`, mirroring the existing convention for `mapDelayAtLeast` / `flatMapLatestDelayAtLeast`:
- `withMinimumDuration pads to delayMillis when block is instant` — verifies virtual elapsed equals `delayMillis`.
- `withMinimumDuration does not pad when block takes longer than delayMillis` — verifies the function does not over-pad.

Both pass under `runTest` (`./gradlew :common:testDebugUnitTest`) and complete near-instantly in real time.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>

Generated with [Claude Code](https://claude.com/claude-code)