### PR TITLE
fix(#90): cancel prior load in DealDetailsViewModel

### DIFF
--- a/feature/deal/src/main/java/pm/bam/gamedeals/feature/deal/ui/DealDetailsViewModel.kt
+++ b/feature/deal/src/main/java/pm/bam/gamedeals/feature/deal/ui/DealDetailsViewModel.kt
@@ -3,6 +3,7 @@ package pm.bam.gamedeals.feature.deal.ui
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -31,13 +32,16 @@ class DealDetailsViewModel @Inject constructor(
     private val _dealDetails = MutableStateFlow<DealBottomSheetData?>(null)
     val dealDealDetails: StateFlow<DealBottomSheetData?> = _dealDetails.asStateFlow()
 
+    private var loadJob: Job? = null
+
     fun loadDealDetails(
         dealId: String,
         dealStoreId: Int,
         dealTitle: String,
         dealPriceDenominated: String
     ) {
-        viewModelScope.launch {
+        loadJob?.cancel()
+        loadJob = viewModelScope.launch {
             flowOf(true)
                 .mapDelayAtLeast(750) {
                     val dealDetails = dealsRepository.getDeal(dealId)

--- a/feature/deal/src/test/java/pm/bam/gamedeals/feature/deal/ui/DealDetailsViewModelTest.kt
+++ b/feature/deal/src/test/java/pm/bam/gamedeals/feature/deal/ui/DealDetailsViewModelTest.kt
@@ -130,4 +130,74 @@ class DealDetailsViewModelTest {
         assertEquals(1, emissions.size)
         assertNull(emissions.first())
     }
+
+    @Test
+    fun `rapid successive loadDealDetails calls only emit the latest deal data`() = runTest {
+        val firstDealId = "First Deal"
+        val firstStoreId = 1
+        val firstDealTitle = "First Title"
+        val firstSalePriceDenominated = "$5"
+        val firstStore: Store = mockk()
+        val firstGameInfo: DealDetails.GameInfo = mockk()
+        val firstCheapestPrice: DealDetails.CheapestPrice = mockk()
+        val firstDealDetails: DealDetails = mockk {
+            every { gameInfo } returns firstGameInfo
+            every { cheapestPrice } returns firstCheapestPrice
+            every { cheaperStores } returns emptyList()
+        }
+
+        val secondDealId = "Second Deal"
+        val secondStoreId = 2
+        val secondDealTitle = "Second Title"
+        val secondSalePriceDenominated = "$10"
+        val secondStore: Store = mockk()
+        val secondGameInfo: DealDetails.GameInfo = mockk()
+        val secondCheapestPrice: DealDetails.CheapestPrice = mockk()
+        val secondDealDetails: DealDetails = mockk {
+            every { gameInfo } returns secondGameInfo
+            every { cheapestPrice } returns secondCheapestPrice
+            every { cheaperStores } returns emptyList()
+        }
+
+        coEvery { dealsRepository.getDeal(firstDealId) } returns firstDealDetails
+        coEvery { dealsRepository.getDeal(secondDealId) } returns secondDealDetails
+        coEvery { storesRepository.getStore(firstStoreId) } returns firstStore
+        coEvery { storesRepository.getStore(secondStoreId) } returns secondStore
+
+        val emissions = viewModel.dealDealDetails.observeEmissions(this.backgroundScope, mainCoroutineRule.testDispatcher)
+
+        viewModel.loadDealDetails(
+            dealId = firstDealId,
+            dealStoreId = firstStoreId,
+            dealTitle = firstDealTitle,
+            dealPriceDenominated = firstSalePriceDenominated
+        )
+
+        viewModel.loadDealDetails(
+            dealId = secondDealId,
+            dealStoreId = secondStoreId,
+            dealTitle = secondDealTitle,
+            dealPriceDenominated = secondSalePriceDenominated
+        )
+
+        delay(1000) // Past mapDelayAtLeast(750) so the surviving load resolves to DealDetailsData.
+
+        val terminal = emissions.last()
+        assertEquals(
+            DealBottomSheetData.DealDetailsData(
+                store = secondStore,
+                gameName = secondDealTitle,
+                dealId = secondDealId,
+                gameSalesPriceDenominated = secondSalePriceDenominated,
+                gameInfo = secondGameInfo,
+                cheapestPrice = secondCheapestPrice,
+                cheaperStores = emptyList()
+            ), terminal
+        )
+
+        // The first load's DealDetailsData (with firstStore/firstGameInfo) must never appear.
+        val firstDealDataEmissions = emissions.filterIsInstance<DealBottomSheetData.DealDetailsData>()
+            .filter { it.dealId == firstDealId }
+        assertEquals(0, firstDealDataEmissions.size)
+    }
 }


### PR DESCRIPTION
Closes #90.

## Summary
- `DealDetailsViewModel.loadDealDetails` now tracks the in-flight load `Job` and cancels it before launching the next, so rapid taps on different deals can't race two coroutines through `mapDelayAtLeast(750)` and have the slower one clobber `_dealDetails`.
- Mirrors the prior-job-cancellation pattern from `HomeViewModel.loadTopStoresDeals` (PR #33) and `DealDetailsController.load` (commit `b64307b`); the `DealDetailsController` path is already covered by that earlier fix, this PR addresses the remaining `feature/deal` path that does not flow through the controller.

## Test plan
- [x] Added `rapid successive loadDealDetails calls only emit the latest deal data` to `DealDetailsViewModelTest` — fires two back-to-back loads, advances past `mapDelayAtLeast(750)`, and asserts the terminal emission is the second deal's `DealDetailsData` and that the first deal's `DealDetailsData` never appears.
- [x] `:feature:deal:testDebugUnitTest --tests DealDetailsViewModelTest` (4/4 pass).

🤖 Generated with [Claude Code](https://claude.com/claude-code)