### PR TITLE
refactor(domain): split Room entities from public domain models

### DIFF
--- a/domain/src/main/java/pm/bam/gamedeals/domain/db/DomainDatabase.kt
+++ b/domain/src/main/java/pm/bam/gamedeals/domain/db/DomainDatabase.kt
@@ -9,17 +9,28 @@ import pm.bam.gamedeals.domain.db.dao.GiveawaysDao
 import pm.bam.gamedeals.domain.db.dao.PagingDao
 import pm.bam.gamedeals.domain.db.dao.ReleasesDao
 import pm.bam.gamedeals.domain.db.dao.StoresDao
-import pm.bam.gamedeals.domain.models.Deal
-import pm.bam.gamedeals.domain.models.DealPage
-import pm.bam.gamedeals.domain.models.Game
-import pm.bam.gamedeals.domain.models.Giveaway
-import pm.bam.gamedeals.domain.models.Release
-import pm.bam.gamedeals.domain.models.Store
+import pm.bam.gamedeals.domain.db.entities.DealEntity
+import pm.bam.gamedeals.domain.db.entities.DealPageEntity
+import pm.bam.gamedeals.domain.db.entities.GameEntity
+import pm.bam.gamedeals.domain.db.entities.GiveawayEntity
+import pm.bam.gamedeals.domain.db.entities.ReleaseEntity
+import pm.bam.gamedeals.domain.db.entities.StoreEntity
 import pm.bam.gamedeals.domain.utils.GiveawayPlatformsConverter
 import pm.bam.gamedeals.domain.utils.LocalDatetimeConverter
 import pm.bam.gamedeals.domain.utils.StoreImagesConverter
 
-@Database(version = 3, entities = [Deal::class, DealPage::class, Game::class, Store::class, Release::class, Giveaway::class], exportSchema = false)
+@Database(
+    version = 3,
+    entities = [
+        DealEntity::class,
+        DealPageEntity::class,
+        GameEntity::class,
+        StoreEntity::class,
+        ReleaseEntity::class,
+        GiveawayEntity::class,
+    ],
+    exportSchema = false,
+)
 @TypeConverters(StoreImagesConverter::class, GiveawayPlatformsConverter::class, LocalDatetimeConverter::class)
 abstract class DomainDatabase : RoomDatabase() {
 

--- a/domain/src/main/java/pm/bam/gamedeals/domain/db/dao/DealsDao.kt
+++ b/domain/src/main/java/pm/bam/gamedeals/domain/db/dao/DealsDao.kt
@@ -6,6 +6,7 @@ import androidx.room.Insert
 import androidx.room.OnConflictStrategy
 import androidx.room.Query
 import kotlinx.coroutines.flow.Flow
+import pm.bam.gamedeals.domain.db.entities.DealEntity
 import pm.bam.gamedeals.domain.models.Deal
 
 
@@ -13,26 +14,36 @@ import pm.bam.gamedeals.domain.models.Deal
 internal interface DealsDao {
 
     /** Returns all the [Deal]s in the database, ordered by their [Deal.releaseDate] in descending order. */
-    @Query("SELECT * FROM Deal ORDER BY releaseDate DESC")
+    @Query("SELECT $DEAL_PUBLIC_COLUMNS FROM Deal ORDER BY releaseDate DESC")
     fun observeAllDeals(): Flow<List<Deal>>
 
-    /** Returns all the [Deal]s in the database with [storeId], ordered by their [Deal.dealRating] in descending order. */
-    @Query("SELECT * FROM Deal WHERE storeID IS :storeId ORDER BY dealRating DESC")
+    /** Returns all the [Deal]s in the database with [storeId], ordered by `dealRating` in descending order. */
+    @Query("SELECT $DEAL_PUBLIC_COLUMNS FROM Deal WHERE storeID IS :storeId ORDER BY dealRating DESC")
     suspend fun getStoreDeals(storeId: Int): List<Deal>
 
-    /** Returns all the [Deal]s in the database with [storeId], ordered by their [Deal.dealRating] in descending order, limited to [limit]. */
-    @Query("SELECT * FROM Deal WHERE storeID IS :storeId ORDER BY dealRating DESC LIMIT :limit")
+    /** Returns all the [Deal]s in the database with [storeId], ordered by `dealRating` in descending order, limited to [limit]. */
+    @Query("SELECT $DEAL_PUBLIC_COLUMNS FROM Deal WHERE storeID IS :storeId ORDER BY dealRating DESC LIMIT :limit")
     suspend fun getStoreDeals(storeId: Int, limit: Int): List<Deal>
 
-    /** Returns all the [Deal]s in the database with [storeId], ordered by their [Deal.dealRating] in descending order. */
-    @Query("SELECT * FROM Deal WHERE storeID IS :storeId ORDER BY dealRating DESC")
+    /** Paged [Deal]s for [storeId], ordered by `dealRating` in descending order. */
+    @Query("SELECT $DEAL_PUBLIC_COLUMNS FROM Deal WHERE storeID IS :storeId ORDER BY dealRating DESC")
     fun getPagingStoreDeals(storeId: Int): PagingSource<Int, Deal>
 
-    /** Adds the [Deal] to the database. */
-    @Insert(onConflict = OnConflictStrategy.REPLACE)
-    suspend fun addDeals(vararg genericItem: Deal)
+    /** Internal cache-side read returning full entities (including `expires`). */
+    @Query("SELECT * FROM Deal WHERE storeID IS :storeId")
+    suspend fun getStoreDealEntities(storeId: Int): List<DealEntity>
 
-    /** Deletes all [Deal]s from the database where the [Deal.storeID] is [storeId]. */
+    /** Adds the [DealEntity] to the database. */
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun addDealEntities(vararg entities: DealEntity)
+
+    /** Deletes all rows from the `Deal` table where `storeID` is [storeId]. */
     @Query("DELETE FROM Deal WHERE storeID IS :storeId")
     suspend fun clearDealsForStore(storeId: Int)
 }
+
+private const val DEAL_PUBLIC_COLUMNS =
+    "dealID, internalName, title, metacriticLink, storeID, gameID, " +
+        "salePriceValue, salePriceDenominated, normalPriceValue, normalPriceDenominated, " +
+        "isOnSale, savings, metacriticScore, steamRatingText, steamRatingPercent, " +
+        "steamRatingCount, steamAppID, releaseDate, lastChange, dealRating, thumb"

--- a/domain/src/main/java/pm/bam/gamedeals/domain/db/dao/GamesDao.kt
+++ b/domain/src/main/java/pm/bam/gamedeals/domain/db/dao/GamesDao.kt
@@ -5,6 +5,7 @@ import androidx.room.Insert
 import androidx.room.OnConflictStrategy
 import androidx.room.Query
 import kotlinx.coroutines.flow.Flow
+import pm.bam.gamedeals.domain.db.entities.GameEntity
 import pm.bam.gamedeals.domain.models.Game
 
 @Dao
@@ -14,7 +15,7 @@ internal interface GamesDao {
     @Query("SELECT * FROM Game")
     fun observeAllGames(): Flow<List<Game>>
 
-    /** Adds the [Game] to the database. */
+    /** Adds the [GameEntity] to the database. */
     @Insert(onConflict = OnConflictStrategy.REPLACE)
-    suspend fun addGames(vararg genericItem: Game)
+    suspend fun addGameEntities(vararg entities: GameEntity)
 }

--- a/domain/src/main/java/pm/bam/gamedeals/domain/db/dao/GiveawaysDao.kt
+++ b/domain/src/main/java/pm/bam/gamedeals/domain/db/dao/GiveawaysDao.kt
@@ -5,6 +5,7 @@ import androidx.room.Insert
 import androidx.room.OnConflictStrategy
 import androidx.room.Query
 import kotlinx.coroutines.flow.Flow
+import pm.bam.gamedeals.domain.db.entities.GiveawayEntity
 import pm.bam.gamedeals.domain.models.Giveaway
 
 @Dao
@@ -14,8 +15,8 @@ internal interface GiveawaysDao {
     @Query("SELECT * FROM Giveaway")
     fun observeAllGiveaways(): Flow<List<Giveaway>>
 
-    /** Adds the [Giveaway] to the database. */
+    /** Adds the [GiveawayEntity] to the database. */
     @Insert(onConflict = OnConflictStrategy.REPLACE)
-    suspend fun addGiveaways(vararg genericItem: Giveaway)
+    suspend fun addGiveawayEntities(vararg entities: GiveawayEntity)
 
 }

--- a/domain/src/main/java/pm/bam/gamedeals/domain/db/dao/PagingDao.kt
+++ b/domain/src/main/java/pm/bam/gamedeals/domain/db/dao/PagingDao.kt
@@ -4,16 +4,16 @@ import androidx.room.Dao
 import androidx.room.Insert
 import androidx.room.OnConflictStrategy
 import androidx.room.Query
-import pm.bam.gamedeals.domain.models.DealPage
+import pm.bam.gamedeals.domain.db.entities.DealPageEntity
 
 @Dao
 internal interface PagingDao {
 
     @Insert(onConflict = OnConflictStrategy.REPLACE)
-    suspend fun insert(dealPage: DealPage)
+    suspend fun insert(dealPage: DealPageEntity)
 
     @Query("SELECT * FROM DealPage WHERE storeID = :storeId")
-    suspend fun getStorePage(storeId: Int): DealPage?
+    suspend fun getStorePage(storeId: Int): DealPageEntity?
 
     @Query("DELETE FROM DealPage WHERE storeID IS :storeId")
     suspend fun clearStorePage(storeId: Int)

--- a/domain/src/main/java/pm/bam/gamedeals/domain/db/dao/ReleasesDao.kt
+++ b/domain/src/main/java/pm/bam/gamedeals/domain/db/dao/ReleasesDao.kt
@@ -5,6 +5,7 @@ import androidx.room.Insert
 import androidx.room.OnConflictStrategy
 import androidx.room.Query
 import kotlinx.coroutines.flow.Flow
+import pm.bam.gamedeals.domain.db.entities.ReleaseEntity
 import pm.bam.gamedeals.domain.models.Release
 
 @Dao
@@ -14,8 +15,8 @@ internal interface ReleasesDao {
     @Query("SELECT * FROM `Release`")
     fun observeAllReleases(): Flow<List<Release>>
 
-    /** Adds the [Release] to the database. */
+    /** Adds the [ReleaseEntity] to the database. */
     @Insert(onConflict = OnConflictStrategy.REPLACE)
-    suspend fun addReleases(vararg genericItem: Release)
+    suspend fun addReleaseEntities(vararg entities: ReleaseEntity)
 
 }

--- a/domain/src/main/java/pm/bam/gamedeals/domain/db/dao/StoresDao.kt
+++ b/domain/src/main/java/pm/bam/gamedeals/domain/db/dao/StoresDao.kt
@@ -5,25 +5,31 @@ import androidx.room.Insert
 import androidx.room.OnConflictStrategy
 import androidx.room.Query
 import kotlinx.coroutines.flow.Flow
+import pm.bam.gamedeals.domain.db.entities.StoreEntity
 import pm.bam.gamedeals.domain.models.Store
 
 @Dao
 internal interface StoresDao {
 
     /** Returns all the [Store]s in the database. */
-    @Query("SELECT * FROM Store")
+    @Query("SELECT $STORE_PUBLIC_COLUMNS FROM Store")
     fun observeAllStores(): Flow<List<Store>>
 
     /** Returns all the [Store]s in the database. */
-    @Query("SELECT * FROM Store")
+    @Query("SELECT $STORE_PUBLIC_COLUMNS FROM Store")
     suspend fun getAllStores(): List<Store>
 
     /** Returns the [Store] in the database where the [Store.storeID] is [storeId]. */
-    @Query("SELECT * FROM Store WHERE storeID = :storeId")
+    @Query("SELECT $STORE_PUBLIC_COLUMNS FROM Store WHERE storeID = :storeId")
     suspend fun getStore(storeId: Int): Store
 
-    /** Adds the [Store] to the database. */
-    @Insert(onConflict = OnConflictStrategy.REPLACE)
-    suspend fun addStores(vararg genericItem: Store)
+    /** Internal cache-side read returning full entities (including `expires`). */
+    @Query("SELECT * FROM Store")
+    suspend fun getAllStoreEntities(): List<StoreEntity>
 
+    /** Adds the [StoreEntity] to the database. */
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun addStoreEntities(vararg entities: StoreEntity)
 }
+
+private const val STORE_PUBLIC_COLUMNS = "storeID, storeName, isActive, images"

--- a/domain/src/main/java/pm/bam/gamedeals/domain/db/entities/DealEntity.kt
+++ b/domain/src/main/java/pm/bam/gamedeals/domain/db/entities/DealEntity.kt
@@ -1,0 +1,40 @@
+package pm.bam.gamedeals.domain.db.entities
+
+import androidx.room.ColumnInfo
+import androidx.room.Entity
+import androidx.room.PrimaryKey
+
+@Entity(tableName = "Deal")
+internal data class DealEntity(
+    @PrimaryKey
+    val dealID: String,
+    val internalName: String,
+    val title: String,
+    val metacriticLink: String? = null,
+    val storeID: Int,
+    val gameID: Int,
+    val salePriceValue: Double,
+    val salePriceDenominated: String,
+    val normalPriceValue: Double,
+    val normalPriceDenominated: String,
+    val isOnSale: Boolean,
+    val savings: Double,
+    val metacriticScore: Int,
+    val steamRatingText: String? = null,
+    val steamRatingPercent: Int,
+    val steamRatingCount: String,
+    val steamAppID: Int? = null,
+    val releaseDate: Int,
+    val lastChange: Int,
+    val dealRating: Double,
+    val thumb: String,
+    val expires: Long = 0L,
+)
+
+@Entity(tableName = "DealPage")
+internal data class DealPageEntity(
+    @PrimaryKey
+    @ColumnInfo(name = "storeID", collate = ColumnInfo.NOCASE)
+    val storeID: Int,
+    val page: Int,
+)

--- a/domain/src/main/java/pm/bam/gamedeals/domain/db/entities/GameEntity.kt
+++ b/domain/src/main/java/pm/bam/gamedeals/domain/db/entities/GameEntity.kt
@@ -1,0 +1,17 @@
+package pm.bam.gamedeals.domain.db.entities
+
+import androidx.room.Entity
+import androidx.room.PrimaryKey
+
+@Entity(tableName = "Game")
+internal data class GameEntity(
+    @PrimaryKey
+    val gameID: Int,
+    val steamAppID: Int? = null,
+    val cheapestValue: Double,
+    val cheapestDenominated: String,
+    val cheapestDealID: String,
+    val title: String,
+    val internalName: String,
+    val thumb: String,
+)

--- a/domain/src/main/java/pm/bam/gamedeals/domain/db/entities/GiveawayEntity.kt
+++ b/domain/src/main/java/pm/bam/gamedeals/domain/db/entities/GiveawayEntity.kt
@@ -1,0 +1,29 @@
+package pm.bam.gamedeals.domain.db.entities
+
+import androidx.room.Entity
+import androidx.room.PrimaryKey
+import pm.bam.gamedeals.domain.models.GiveawayPlatform
+import pm.bam.gamedeals.domain.models.GiveawayType
+import java.time.LocalDateTime
+
+@Entity(tableName = "Giveaway")
+internal data class GiveawayEntity(
+    @PrimaryKey
+    val id: Int,
+    val title: String,
+    val worthDenominated: String?,
+    val worth: Double?,
+    val thumbnail: String,
+    val image: String,
+    val description: String,
+    val instructions: String,
+    val openGiveawayUrl: String,
+    val publishedDate: LocalDateTime,
+    val type: GiveawayType,
+    val platforms: List<GiveawayPlatform>,
+    val endDate: String?,
+    val users: Int,
+    val status: String,
+    val gamerpowerUrl: String,
+    val openGiveaway: String,
+)

--- a/domain/src/main/java/pm/bam/gamedeals/domain/db/entities/Mappers.kt
+++ b/domain/src/main/java/pm/bam/gamedeals/domain/db/entities/Mappers.kt
@@ -1,0 +1,77 @@
+package pm.bam.gamedeals.domain.db.entities
+
+import pm.bam.gamedeals.domain.models.Deal
+import pm.bam.gamedeals.domain.models.Game
+import pm.bam.gamedeals.domain.models.Giveaway
+import pm.bam.gamedeals.domain.models.Release
+import pm.bam.gamedeals.domain.models.Store
+
+internal fun Deal.toEntity(expiresAt: Long = 0L): DealEntity = DealEntity(
+    dealID = dealID,
+    internalName = internalName,
+    title = title,
+    metacriticLink = metacriticLink,
+    storeID = storeID,
+    gameID = gameID,
+    salePriceValue = salePriceValue,
+    salePriceDenominated = salePriceDenominated,
+    normalPriceValue = normalPriceValue,
+    normalPriceDenominated = normalPriceDenominated,
+    isOnSale = isOnSale,
+    savings = savings,
+    metacriticScore = metacriticScore,
+    steamRatingText = steamRatingText,
+    steamRatingPercent = steamRatingPercent,
+    steamRatingCount = steamRatingCount,
+    steamAppID = steamAppID,
+    releaseDate = releaseDate,
+    lastChange = lastChange,
+    dealRating = dealRating,
+    thumb = thumb,
+    expires = expiresAt,
+)
+
+internal fun Store.toEntity(expiresAt: Long = 0L): StoreEntity = StoreEntity(
+    storeID = storeID,
+    storeName = storeName,
+    isActive = isActive,
+    images = images,
+    expires = expiresAt,
+)
+
+internal fun Game.toEntity(): GameEntity = GameEntity(
+    gameID = gameID,
+    steamAppID = steamAppID,
+    cheapestValue = cheapestValue,
+    cheapestDenominated = cheapestDenominated,
+    cheapestDealID = cheapestDealID,
+    title = title,
+    internalName = internalName,
+    thumb = thumb,
+)
+
+internal fun Release.toEntity(): ReleaseEntity = ReleaseEntity(
+    title = title,
+    date = date,
+    image = image,
+)
+
+internal fun Giveaway.toEntity(): GiveawayEntity = GiveawayEntity(
+    id = id,
+    title = title,
+    worthDenominated = worthDenominated,
+    worth = worth,
+    thumbnail = thumbnail,
+    image = image,
+    description = description,
+    instructions = instructions,
+    openGiveawayUrl = openGiveawayUrl,
+    publishedDate = publishedDate,
+    type = type,
+    platforms = platforms,
+    endDate = endDate,
+    users = users,
+    status = status,
+    gamerpowerUrl = gamerpowerUrl,
+    openGiveaway = openGiveaway,
+)

--- a/domain/src/main/java/pm/bam/gamedeals/domain/db/entities/ReleaseEntity.kt
+++ b/domain/src/main/java/pm/bam/gamedeals/domain/db/entities/ReleaseEntity.kt
@@ -1,0 +1,12 @@
+package pm.bam.gamedeals.domain.db.entities
+
+import androidx.room.Entity
+import androidx.room.PrimaryKey
+
+@Entity(tableName = "Release")
+internal data class ReleaseEntity(
+    @PrimaryKey
+    val title: String,
+    val date: Int,
+    val image: String,
+)

--- a/domain/src/main/java/pm/bam/gamedeals/domain/db/entities/StoreEntity.kt
+++ b/domain/src/main/java/pm/bam/gamedeals/domain/db/entities/StoreEntity.kt
@@ -1,0 +1,15 @@
+package pm.bam.gamedeals.domain.db.entities
+
+import androidx.room.Entity
+import androidx.room.PrimaryKey
+import pm.bam.gamedeals.domain.models.Store
+
+@Entity(tableName = "Store")
+internal data class StoreEntity(
+    @PrimaryKey
+    val storeID: Int,
+    val storeName: String,
+    val isActive: Boolean,
+    val images: Store.StoreImages,
+    val expires: Long = 0L,
+)

--- a/domain/src/main/java/pm/bam/gamedeals/domain/models/Deal.kt
+++ b/domain/src/main/java/pm/bam/gamedeals/domain/models/Deal.kt
@@ -2,22 +2,13 @@ package pm.bam.gamedeals.domain.models
 
 
 import androidx.compose.runtime.Immutable
-import androidx.room.ColumnInfo
-import androidx.room.Entity
-import androidx.room.PrimaryKey
-import kotlinx.serialization.EncodeDefault
-import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
-@OptIn(ExperimentalSerializationApi::class)
 @Immutable
-@Entity(tableName = "Deal")
 @Serializable
 data class Deal(
-    @PrimaryKey
     @SerialName("dealID")
-    @EncodeDefault(EncodeDefault.Mode.NEVER)
     val dealID: String,
     @SerialName("internalName")
     val internalName: String,
@@ -59,16 +50,6 @@ data class Deal(
     val dealRating: Double,
     @SerialName("thumb")
     val thumb: String,
-
-    /**
-     * Epoch-millisecond expiry stamp written when the entity is persisted by the repository.
-     *
-     * The repository stamps this via the injected `Clock` plus the resource's TTL when adding
-     * fetched entities to the DAO; defaults to `0L` (already-expired) so any unstamped entity
-     * is considered stale by the cache.
-     */
-    @SerialName("expires")
-    val expires: Long = 0L
 )
 
 @Serializable
@@ -145,12 +126,3 @@ data class DealDetails(
         val date: String
     )
 }
-
-@Entity(tableName = "DealPage")
-internal data class DealPage(
-    @PrimaryKey
-    @ColumnInfo(name = "storeID", collate = ColumnInfo.NOCASE)
-    val storeID: Int,
-    @SerialName("page")
-    val page: Int
-)

--- a/domain/src/main/java/pm/bam/gamedeals/domain/models/Game.kt
+++ b/domain/src/main/java/pm/bam/gamedeals/domain/models/Game.kt
@@ -2,16 +2,12 @@ package pm.bam.gamedeals.domain.models
 
 
 import androidx.compose.runtime.Immutable
-import androidx.room.Entity
-import androidx.room.PrimaryKey
 import kotlinx.collections.immutable.ImmutableList
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
-@Entity(tableName = "Game")
 @Serializable
 data class Game(
-    @PrimaryKey
     @SerialName("gameID")
     val gameID: Int,
     @SerialName("steamAppID")

--- a/domain/src/main/java/pm/bam/gamedeals/domain/models/Giveaway.kt
+++ b/domain/src/main/java/pm/bam/gamedeals/domain/models/Giveaway.kt
@@ -2,8 +2,6 @@ package pm.bam.gamedeals.domain.models
 
 
 import androidx.compose.runtime.Immutable
-import androidx.room.Entity
-import androidx.room.PrimaryKey
 import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.toImmutableList
 import kotlinx.serialization.ExperimentalSerializationApi
@@ -13,10 +11,8 @@ import kotlinx.serialization.properties.Properties
 import pm.bam.gamedeals.domain.utils.LocalDateSerializer
 import java.time.LocalDateTime
 
-@Entity(tableName = "Giveaway")
 @Serializable
 data class Giveaway(
-    @PrimaryKey
     @SerialName("id")
     val id: Int,
     @SerialName("title")

--- a/domain/src/main/java/pm/bam/gamedeals/domain/models/Release.kt
+++ b/domain/src/main/java/pm/bam/gamedeals/domain/models/Release.kt
@@ -1,16 +1,12 @@
 package pm.bam.gamedeals.domain.models
 
 import androidx.compose.runtime.Immutable
-import androidx.room.Entity
-import androidx.room.PrimaryKey
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 @Immutable
-@Entity(tableName = "Release")
 @Serializable
 data class Release(
-    @PrimaryKey
     @SerialName("title")
     val title: String,
     @SerialName("date")

--- a/domain/src/main/java/pm/bam/gamedeals/domain/models/Store.kt
+++ b/domain/src/main/java/pm/bam/gamedeals/domain/models/Store.kt
@@ -2,16 +2,12 @@ package pm.bam.gamedeals.domain.models
 
 
 import androidx.compose.runtime.Immutable
-import androidx.room.Entity
-import androidx.room.PrimaryKey
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 @Immutable
-@Entity(tableName = "Store")
 @Serializable
 data class Store(
-    @PrimaryKey
     @SerialName("storeID")
     val storeID: Int,
     @SerialName("storeName")
@@ -20,16 +16,6 @@ data class Store(
     val isActive: Boolean,
     @SerialName("images")
     val images: StoreImages,
-
-    /**
-     * Epoch-millisecond expiry stamp written when the entity is persisted by the repository.
-     *
-     * The repository stamps this via the injected `Clock` plus the resource's TTL when adding
-     * fetched entities to the DAO; defaults to `0L` (already-expired) so any unstamped entity
-     * is considered stale by the cache.
-     */
-    @SerialName("expires")
-    val expires: Long = 0L
 ) {
     @Immutable
     @Serializable

--- a/domain/src/main/java/pm/bam/gamedeals/domain/repositories/deals/DealsRepository.kt
+++ b/domain/src/main/java/pm/bam/gamedeals/domain/repositories/deals/DealsRepository.kt
@@ -10,6 +10,8 @@ import kotlinx.serialization.ExperimentalSerializationApi
 import pm.bam.gamedeals.common.time.Clock
 import pm.bam.gamedeals.domain.db.DomainDatabase
 import pm.bam.gamedeals.domain.db.dao.DealsDao
+import pm.bam.gamedeals.domain.db.entities.DealEntity
+import pm.bam.gamedeals.domain.db.entities.toEntity
 import pm.bam.gamedeals.domain.models.Deal
 import pm.bam.gamedeals.domain.models.DealDetails
 import pm.bam.gamedeals.domain.models.SearchParameters
@@ -69,17 +71,17 @@ class DealsRepository @Inject internal constructor(
     }
 
     @OptIn(ExperimentalSerializationApi::class)
-    private fun storeDealsCache(storeId: Int): CachedResource<Deal> = CachedResource(
+    private fun storeDealsCache(storeId: Int): CachedResource<DealEntity> = CachedResource(
         clock = clock,
-        read = { dealsDao.getStoreDeals(storeId) },
+        read = { dealsDao.getStoreDealEntities(storeId) },
         expiresAtMillis = { it.expires },
         refresh = {
             val expiresAt = clock.nowMillis() + DEALS_TTL_MILLIS
             domainDatabase.withTransaction {
                 dealsDao.clearDealsForStore(storeId)
                 cheapsharkSource.fetchDealsForStore(SearchParameters(storeID = storeId, pageSize = DEAL_PAGE_COUNT))
-                    .map { it.copy(expires = expiresAt) }
-                    .let { dealsDao.addDeals(*it.toTypedArray()) }
+                    .map { it.toEntity(expiresAt = expiresAt) }
+                    .let { dealsDao.addDealEntities(*it.toTypedArray()) }
             }
         }
     )

--- a/domain/src/main/java/pm/bam/gamedeals/domain/repositories/deals/paging/DealsMediator.kt
+++ b/domain/src/main/java/pm/bam/gamedeals/domain/repositories/deals/paging/DealsMediator.kt
@@ -11,8 +11,9 @@ import androidx.room.withTransaction
 import kotlinx.coroutines.CancellationException
 import kotlinx.serialization.ExperimentalSerializationApi
 import pm.bam.gamedeals.domain.db.DomainDatabase
+import pm.bam.gamedeals.domain.db.entities.DealPageEntity
+import pm.bam.gamedeals.domain.db.entities.toEntity
 import pm.bam.gamedeals.domain.models.Deal
-import pm.bam.gamedeals.domain.models.DealPage
 import pm.bam.gamedeals.domain.models.DealsSortBy
 import pm.bam.gamedeals.domain.models.SearchParameters
 import pm.bam.gamedeals.domain.source.CheapsharkSource
@@ -64,11 +65,11 @@ internal class DealsMediator(
                     pagingDao.clearStorePage(storeId)
                 }
 
-                val newDealPage = DealPage(storeId, pageNumber + 1)
+                val newDealPage = DealPageEntity(storeId, pageNumber + 1)
                 debug(logger) { "New DealPage: $newDealPage" }
 
                 pagingDao.insert(newDealPage)
-                dealsDao.addDeals(*deals.toTypedArray())
+                dealsDao.addDealEntities(*deals.map { it.toEntity() }.toTypedArray())
                 debug(logger) { "Stored new Deals" }
             }
 

--- a/domain/src/main/java/pm/bam/gamedeals/domain/repositories/games/GamesRepository.kt
+++ b/domain/src/main/java/pm/bam/gamedeals/domain/repositories/games/GamesRepository.kt
@@ -4,6 +4,7 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.onStart
 import kotlinx.serialization.ExperimentalSerializationApi
 import pm.bam.gamedeals.domain.db.dao.GamesDao
+import pm.bam.gamedeals.domain.db.entities.toEntity
 import pm.bam.gamedeals.domain.models.Deal
 import pm.bam.gamedeals.domain.models.Game
 import pm.bam.gamedeals.domain.models.GameDetails
@@ -40,5 +41,6 @@ class GamesRepository @Inject internal constructor(
 
     suspend fun refreshGames() =
         cheapsharkSource.fetchGames("")
-            .let { gamesDao.addGames(*it.toTypedArray()) }
+            .map { it.toEntity() }
+            .let { gamesDao.addGameEntities(*it.toTypedArray()) }
 }

--- a/domain/src/main/java/pm/bam/gamedeals/domain/repositories/giveaway/GiveawaysRepository.kt
+++ b/domain/src/main/java/pm/bam/gamedeals/domain/repositories/giveaway/GiveawaysRepository.kt
@@ -4,6 +4,7 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
 import pm.bam.gamedeals.common.onError
 import pm.bam.gamedeals.domain.db.dao.GiveawaysDao
+import pm.bam.gamedeals.domain.db.entities.toEntity
 import pm.bam.gamedeals.domain.models.Giveaway
 import pm.bam.gamedeals.domain.models.GiveawaySearchParameters
 import pm.bam.gamedeals.domain.models.GiveawaySortBy
@@ -55,5 +56,6 @@ class GiveawaysRepository @Inject internal constructor(
 
     suspend fun refreshGiveaways() =
         gamerPowerSource.fetchGiveaways()
-            .let { giveawaysDao.addGiveaways(*it.toTypedArray()) }
+            .map { it.toEntity() }
+            .let { giveawaysDao.addGiveawayEntities(*it.toTypedArray()) }
 }

--- a/domain/src/main/java/pm/bam/gamedeals/domain/repositories/releases/ReleasesRepository.kt
+++ b/domain/src/main/java/pm/bam/gamedeals/domain/repositories/releases/ReleasesRepository.kt
@@ -4,6 +4,7 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.onStart
 import pm.bam.gamedeals.common.onError
 import pm.bam.gamedeals.domain.db.dao.ReleasesDao
+import pm.bam.gamedeals.domain.db.entities.toEntity
 import pm.bam.gamedeals.domain.models.Release
 import pm.bam.gamedeals.domain.source.CheapsharkSource
 import pm.bam.gamedeals.logging.Logger
@@ -25,5 +26,6 @@ class ReleasesRepository @Inject internal constructor(
 
     suspend fun refreshReleases() =
         cheapsharkSource.fetchReleases()
-            .let { releasesDao.addReleases(*it.toTypedArray()) }
+            .map { it.toEntity() }
+            .let { releasesDao.addReleaseEntities(*it.toTypedArray()) }
 }

--- a/domain/src/main/java/pm/bam/gamedeals/domain/repositories/stores/StoresRepository.kt
+++ b/domain/src/main/java/pm/bam/gamedeals/domain/repositories/stores/StoresRepository.kt
@@ -4,6 +4,7 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.onStart
 import pm.bam.gamedeals.common.time.Clock
 import pm.bam.gamedeals.domain.db.dao.StoresDao
+import pm.bam.gamedeals.domain.db.entities.toEntity
 import pm.bam.gamedeals.domain.models.Store
 import pm.bam.gamedeals.domain.repositories.cache.CachedResource
 import pm.bam.gamedeals.domain.source.CheapsharkSource
@@ -25,13 +26,13 @@ class StoresRepository @Inject internal constructor(
 
     private val cache = CachedResource(
         clock = clock,
-        read = { storesDao.getAllStores() },
+        read = { storesDao.getAllStoreEntities() },
         expiresAtMillis = { it.expires },
         refresh = {
             val expiresAt = clock.nowMillis() + STORES_TTL_MILLIS
             cheapsharkSource.fetchStores()
-                .map { it.copy(expires = expiresAt) }
-                .let { storesDao.addStores(*it.toTypedArray()) }
+                .map { it.toEntity(expiresAt = expiresAt) }
+                .let { storesDao.addStoreEntities(*it.toTypedArray()) }
         }
     )
 

--- a/domain/src/test/java/pm/bam/gamedeals/domain/db/entities/MappersTest.kt
+++ b/domain/src/test/java/pm/bam/gamedeals/domain/db/entities/MappersTest.kt
@@ -1,0 +1,187 @@
+package pm.bam.gamedeals.domain.db.entities
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import pm.bam.gamedeals.domain.models.Deal
+import pm.bam.gamedeals.domain.models.Game
+import pm.bam.gamedeals.domain.models.Giveaway
+import pm.bam.gamedeals.domain.models.GiveawayPlatform
+import pm.bam.gamedeals.domain.models.GiveawayType
+import pm.bam.gamedeals.domain.models.Release
+import pm.bam.gamedeals.domain.models.Store
+import java.time.LocalDateTime
+
+internal class MappersTest {
+
+    @Test
+    fun `Deal toEntity copies every field and stamps expires`() {
+        val deal = Deal(
+            dealID = "deal-1",
+            internalName = "INTERNAL",
+            title = "Title",
+            metacriticLink = "/m/link",
+            storeID = 7,
+            gameID = 42,
+            salePriceValue = 9.99,
+            salePriceDenominated = "$9.99",
+            normalPriceValue = 19.99,
+            normalPriceDenominated = "$19.99",
+            isOnSale = true,
+            savings = 50.0,
+            metacriticScore = 88,
+            steamRatingText = "Very Positive",
+            steamRatingPercent = 95,
+            steamRatingCount = "12345",
+            steamAppID = 123,
+            releaseDate = 1_700_000_000,
+            lastChange = 1_700_500_000,
+            dealRating = 8.5,
+            thumb = "https://thumb",
+        )
+
+        val entity = deal.toEntity(expiresAt = 4_242L)
+
+        assertEquals(deal.dealID, entity.dealID)
+        assertEquals(deal.internalName, entity.internalName)
+        assertEquals(deal.title, entity.title)
+        assertEquals(deal.metacriticLink, entity.metacriticLink)
+        assertEquals(deal.storeID, entity.storeID)
+        assertEquals(deal.gameID, entity.gameID)
+        assertEquals(deal.salePriceValue, entity.salePriceValue, 0.0)
+        assertEquals(deal.salePriceDenominated, entity.salePriceDenominated)
+        assertEquals(deal.normalPriceValue, entity.normalPriceValue, 0.0)
+        assertEquals(deal.normalPriceDenominated, entity.normalPriceDenominated)
+        assertEquals(deal.isOnSale, entity.isOnSale)
+        assertEquals(deal.savings, entity.savings, 0.0)
+        assertEquals(deal.metacriticScore, entity.metacriticScore)
+        assertEquals(deal.steamRatingText, entity.steamRatingText)
+        assertEquals(deal.steamRatingPercent, entity.steamRatingPercent)
+        assertEquals(deal.steamRatingCount, entity.steamRatingCount)
+        assertEquals(deal.steamAppID, entity.steamAppID)
+        assertEquals(deal.releaseDate, entity.releaseDate)
+        assertEquals(deal.lastChange, entity.lastChange)
+        assertEquals(deal.dealRating, entity.dealRating, 0.0)
+        assertEquals(deal.thumb, entity.thumb)
+        assertEquals(4_242L, entity.expires)
+    }
+
+    @Test
+    fun `Deal toEntity defaults expires to zero`() {
+        val deal = sampleDeal()
+        assertEquals(0L, deal.toEntity().expires)
+    }
+
+    @Test
+    fun `Store toEntity copies every field and stamps expires`() {
+        val store = Store(
+            storeID = 3,
+            storeName = "Steam",
+            isActive = true,
+            images = Store.StoreImages(banner = "/b", logo = "/l", icon = "/i"),
+        )
+
+        val entity = store.toEntity(expiresAt = 9_999L)
+
+        assertEquals(store.storeID, entity.storeID)
+        assertEquals(store.storeName, entity.storeName)
+        assertEquals(store.isActive, entity.isActive)
+        assertEquals(store.images, entity.images)
+        assertEquals(9_999L, entity.expires)
+    }
+
+    @Test
+    fun `Store toEntity defaults expires to zero`() {
+        val store = Store(1, "n", true, Store.StoreImages("b", "l", "i"))
+        assertEquals(0L, store.toEntity().expires)
+    }
+
+    @Test
+    fun `Game toEntity copies every field`() {
+        val game = Game(
+            gameID = 11,
+            steamAppID = 22,
+            cheapestValue = 4.99,
+            cheapestDenominated = "$4.99",
+            cheapestDealID = "d-1",
+            title = "Title",
+            internalName = "INTERNAL",
+            thumb = "https://thumb",
+        )
+
+        val entity = game.toEntity()
+
+        assertEquals(game.gameID, entity.gameID)
+        assertEquals(game.steamAppID, entity.steamAppID)
+        assertEquals(game.cheapestValue, entity.cheapestValue, 0.0)
+        assertEquals(game.cheapestDenominated, entity.cheapestDenominated)
+        assertEquals(game.cheapestDealID, entity.cheapestDealID)
+        assertEquals(game.title, entity.title)
+        assertEquals(game.internalName, entity.internalName)
+        assertEquals(game.thumb, entity.thumb)
+    }
+
+    @Test
+    fun `Release toEntity copies every field`() {
+        val release = Release(title = "Game", date = 1_700_000_000, image = "https://i")
+        val entity = release.toEntity()
+
+        assertEquals(release.title, entity.title)
+        assertEquals(release.date, entity.date)
+        assertEquals(release.image, entity.image)
+    }
+
+    @Test
+    fun `Giveaway toEntity copies every field`() {
+        val published = LocalDateTime.of(2026, 5, 1, 12, 30)
+        val giveaway = Giveaway(
+            id = 99,
+            title = "Free Game",
+            worthDenominated = "$10.00",
+            worth = 10.0,
+            thumbnail = "https://thumb",
+            image = "https://image",
+            description = "desc",
+            instructions = "claim it",
+            openGiveawayUrl = "https://open",
+            publishedDate = published,
+            type = GiveawayType.GAME,
+            platforms = listOf(GiveawayPlatform.PC, GiveawayPlatform.STEAM),
+            endDate = "2026-06-01",
+            users = 1234,
+            status = "Active",
+            gamerpowerUrl = "https://gp",
+            openGiveaway = "https://og",
+        )
+
+        val entity = giveaway.toEntity()
+
+        assertEquals(giveaway.id, entity.id)
+        assertEquals(giveaway.title, entity.title)
+        assertEquals(giveaway.worthDenominated, entity.worthDenominated)
+        assertEquals(giveaway.worth, entity.worth)
+        assertEquals(giveaway.thumbnail, entity.thumbnail)
+        assertEquals(giveaway.image, entity.image)
+        assertEquals(giveaway.description, entity.description)
+        assertEquals(giveaway.instructions, entity.instructions)
+        assertEquals(giveaway.openGiveawayUrl, entity.openGiveawayUrl)
+        assertEquals(giveaway.publishedDate, entity.publishedDate)
+        assertEquals(giveaway.type, entity.type)
+        assertEquals(giveaway.platforms, entity.platforms)
+        assertEquals(giveaway.endDate, entity.endDate)
+        assertEquals(giveaway.users, entity.users)
+        assertEquals(giveaway.status, entity.status)
+        assertEquals(giveaway.gamerpowerUrl, entity.gamerpowerUrl)
+        assertEquals(giveaway.openGiveaway, entity.openGiveaway)
+    }
+
+    private fun sampleDeal() = Deal(
+        dealID = "x", internalName = "x", title = "x", metacriticLink = null,
+        storeID = 0, gameID = 0,
+        salePriceValue = 0.0, salePriceDenominated = "",
+        normalPriceValue = 0.0, normalPriceDenominated = "",
+        isOnSale = false, savings = 0.0, metacriticScore = 0,
+        steamRatingText = null, steamRatingPercent = 0, steamRatingCount = "",
+        steamAppID = null, releaseDate = 0, lastChange = 0,
+        dealRating = 0.0, thumb = "",
+    )
+}

--- a/domain/src/test/java/pm/bam/gamedeals/domain/repositories/deals/DealsRepositoryTest.kt
+++ b/domain/src/test/java/pm/bam/gamedeals/domain/repositories/deals/DealsRepositoryTest.kt
@@ -10,10 +10,12 @@ import io.mockk.mockk
 import io.mockk.mockkStatic
 import io.mockk.runs
 import io.mockk.slot
+import io.mockk.unmockkAll
 import io.mockk.verify
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.runTest
+import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Rule
@@ -21,6 +23,8 @@ import org.junit.Test
 import pm.bam.gamedeals.common.time.Clock
 import pm.bam.gamedeals.domain.db.DomainDatabase
 import pm.bam.gamedeals.domain.db.dao.DealsDao
+import pm.bam.gamedeals.domain.db.entities.DealEntity
+import pm.bam.gamedeals.domain.db.entities.toEntity
 import pm.bam.gamedeals.domain.models.Deal
 import pm.bam.gamedeals.domain.models.DealDetails
 import pm.bam.gamedeals.domain.source.CheapsharkSource
@@ -46,6 +50,11 @@ class DealsRepositoryTest {
     private val clock = Clock { now }
 
     private val impl = DealsRepository(logger, dealsDao, domainDatabase, cheapsharkSource, clock)
+
+    @After
+    fun tearDown() {
+        unmockkAll()
+    }
 
 
     @Test
@@ -78,8 +87,9 @@ class DealsRepositoryTest {
     fun `refreshDeals - forced - fetches via source, stamps expires, writes to DAO`() = runTest {
         val storeId = 1
         val fetched: Deal = mockk()
-        val stamped: Deal = mockk()
-        every { fetched.copy(expires = now + millisInHour * 8) } returns stamped
+        val stamped: DealEntity = mockk()
+        mockkStatic("pm.bam.gamedeals.domain.db.entities.MappersKt")
+        every { fetched.toEntity(expiresAt = now + millisInHour * 8) } returns stamped
 
         mockkStatic("androidx.room.RoomDatabaseKt")
         val transactionLambda = slot<suspend () -> Unit>()
@@ -87,7 +97,7 @@ class DealsRepositoryTest {
 
         coEvery { dealsDao.clearDealsForStore(storeId) } just runs
         coEvery { cheapsharkSource.fetchDealsForStore(query = any()) } returns listOf(fetched)
-        coEvery { dealsDao.addDeals(*anyVararg()) } just runs
+        coEvery { dealsDao.addDealEntities(*anyVararg()) } just runs
 
 
         impl.refreshDeals(storeId, force = true)
@@ -95,20 +105,21 @@ class DealsRepositoryTest {
 
         coVerify(exactly = 1) { dealsDao.clearDealsForStore(storeId) }
         coVerify(exactly = 1) { cheapsharkSource.fetchDealsForStore(query = any()) }
-        coVerify(exactly = 1) { dealsDao.addDeals(stamped) }
-        verify(exactly = 1) { fetched.copy(expires = now + millisInHour * 8) }
+        coVerify(exactly = 1) { dealsDao.addDealEntities(stamped) }
+        verify(exactly = 1) { fetched.toEntity(expiresAt = now + millisInHour * 8) }
     }
 
 
     @Test
     fun `refreshDeals - unforced - expired deals - fetches via source`() = runTest {
         val storeId = 1
-        val expired: Deal = mockk { every { expires } returns now - 10_000 }
+        val expired: DealEntity = mockk { every { expires } returns now - 10_000 }
         val fetched: Deal = mockk()
-        val stamped: Deal = mockk()
-        every { fetched.copy(expires = now + millisInHour * 8) } returns stamped
+        val stamped: DealEntity = mockk()
+        mockkStatic("pm.bam.gamedeals.domain.db.entities.MappersKt")
+        every { fetched.toEntity(expiresAt = now + millisInHour * 8) } returns stamped
 
-        coEvery { dealsDao.getStoreDeals(storeId) } returns listOf(expired)
+        coEvery { dealsDao.getStoreDealEntities(storeId) } returns listOf(expired)
 
         mockkStatic("androidx.room.RoomDatabaseKt")
         val transactionLambda = slot<suspend () -> Unit>()
@@ -116,7 +127,7 @@ class DealsRepositoryTest {
 
         coEvery { dealsDao.clearDealsForStore(storeId) } just runs
         coEvery { cheapsharkSource.fetchDealsForStore(query = any()) } returns listOf(fetched)
-        coEvery { dealsDao.addDeals(*anyVararg()) } just runs
+        coEvery { dealsDao.addDealEntities(*anyVararg()) } just runs
 
 
         impl.refreshDeals(storeId)
@@ -124,15 +135,15 @@ class DealsRepositoryTest {
 
         coVerify(exactly = 1) { dealsDao.clearDealsForStore(storeId) }
         coVerify(exactly = 1) { cheapsharkSource.fetchDealsForStore(query = any()) }
-        coVerify(exactly = 1) { dealsDao.addDeals(stamped) }
+        coVerify(exactly = 1) { dealsDao.addDealEntities(stamped) }
     }
 
 
     @Test
     fun `refreshDeals - unforced - skips source when DAO has fresh deals`() = runTest {
         val storeId = 1
-        val fresh: Deal = mockk { every { expires } returns now + 10_000 }
-        coEvery { dealsDao.getStoreDeals(storeId) } returns listOf(fresh)
+        val fresh: DealEntity = mockk { every { expires } returns now + 10_000 }
+        coEvery { dealsDao.getStoreDealEntities(storeId) } returns listOf(fresh)
 
 
         impl.refreshDeals(storeId)

--- a/domain/src/test/java/pm/bam/gamedeals/domain/repositories/deals/paging/DealsMediatorTest.kt
+++ b/domain/src/test/java/pm/bam/gamedeals/domain/repositories/deals/paging/DealsMediatorTest.kt
@@ -15,8 +15,10 @@ import io.mockk.mockk
 import io.mockk.mockkStatic
 import io.mockk.runs
 import io.mockk.slot
+import io.mockk.unmockkAll
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.test.runTest
+import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertSame
@@ -28,8 +30,10 @@ import org.junit.Test
 import pm.bam.gamedeals.domain.db.DomainDatabase
 import pm.bam.gamedeals.domain.db.dao.DealsDao
 import pm.bam.gamedeals.domain.db.dao.PagingDao
+import pm.bam.gamedeals.domain.db.entities.DealEntity
+import pm.bam.gamedeals.domain.db.entities.DealPageEntity
+import pm.bam.gamedeals.domain.db.entities.toEntity
 import pm.bam.gamedeals.domain.models.Deal
-import pm.bam.gamedeals.domain.models.DealPage
 import pm.bam.gamedeals.domain.source.CheapsharkSource
 import pm.bam.gamedeals.logging.Logger
 
@@ -66,6 +70,11 @@ internal class DealsMediatorTest {
         coEvery { domainDatabase.withTransaction(capture(transactionLambda)) } coAnswers { transactionLambda.captured.invoke() }
     }
 
+    @After
+    fun tearDown() {
+        unmockkAll()
+    }
+
 
     @Test
     fun `prepend results in Success with EndOfPage equal True`() = runTest {
@@ -83,17 +92,20 @@ internal class DealsMediatorTest {
     @Test
     fun `APPEND results in Success with EndOfPage equal True`() = runTest {
         val page = 0
-        val dealPage = DealPage(defaultStoreId, page)
-        val newDealPage = DealPage(defaultStoreId, page + 1)
+        val dealPage = DealPageEntity(defaultStoreId, page)
+        val newDealPage = DealPageEntity(defaultStoreId, page + 1)
 
         val deal: Deal = mockk()
+        val dealEntity: DealEntity = mockk()
+        mockkStatic("pm.bam.gamedeals.domain.db.entities.MappersKt")
+        every { deal.toEntity(expiresAt = 0L) } returns dealEntity
 
         coEvery { cheapsharkSource.fetchDealsForStore(query = any()) } returns listOf(deal)
 
         coEvery { pagingDao.getStorePage(defaultStoreId) } returns dealPage
         coEvery { pagingDao.insert(newDealPage) } just runs
 
-        coEvery { dealsDao.addDeals(any()) } just runs
+        coEvery { dealsDao.addDealEntities(any()) } just runs
 
 
         val result: RemoteMediator.MediatorResult = mediator.load(LoadType.APPEND, state)
@@ -109,14 +121,14 @@ internal class DealsMediatorTest {
         coVerify(exactly = 0) { pagingDao.clearStorePage(any()) }
 
         coVerify(exactly = 1) { pagingDao.insert(eq(newDealPage)) }
-        coVerify(exactly = 1) { dealsDao.addDeals(any()) }
+        coVerify(exactly = 1) { dealsDao.addDealEntities(dealEntity) }
     }
 
 
     @Test
     fun `APPEND results in Error`() = runTest {
         val page = 0
-        val dealPage = DealPage(defaultStoreId, page)
+        val dealPage = DealPageEntity(defaultStoreId, page)
         val exception: Exception = mockk()
 
         coEvery { pagingDao.getStorePage(defaultStoreId) } returns dealPage
@@ -137,14 +149,14 @@ internal class DealsMediatorTest {
         coVerify(exactly = 0) { pagingDao.clearStorePage(any()) }
 
         coVerify(exactly = 0) { pagingDao.insert(any()) }
-        coVerify(exactly = 0) { dealsDao.addDeals(any()) }
+        coVerify(exactly = 0) { dealsDao.addDealEntities(*anyVararg()) }
     }
 
 
     @Test
     fun `APPEND rethrows CancellationException instead of returning Error`() = runTest {
         val page = 0
-        val dealPage = DealPage(defaultStoreId, page)
+        val dealPage = DealPageEntity(defaultStoreId, page)
         val cancellation = CancellationException("scope cancelled")
 
         coEvery { pagingDao.getStorePage(defaultStoreId) } returns dealPage
@@ -168,9 +180,12 @@ internal class DealsMediatorTest {
     @Test
     fun `REFRESH results in Success with EndOfPage equal True`() = runTest {
         val page = 0
-        val newDealPage = DealPage(defaultStoreId, page + 1)
+        val newDealPage = DealPageEntity(defaultStoreId, page + 1)
 
         val deal: Deal = mockk()
+        val dealEntity: DealEntity = mockk()
+        mockkStatic("pm.bam.gamedeals.domain.db.entities.MappersKt")
+        every { deal.toEntity(expiresAt = 0L) } returns dealEntity
 
         coEvery { cheapsharkSource.fetchDealsForStore(query = any()) } returns listOf(deal)
 
@@ -178,7 +193,7 @@ internal class DealsMediatorTest {
         coEvery { pagingDao.insert(newDealPage) } just runs
 
         coEvery { dealsDao.clearDealsForStore(defaultStoreId) } just runs
-        coEvery { dealsDao.addDeals(any()) } just runs
+        coEvery { dealsDao.addDealEntities(any()) } just runs
 
 
         val result: RemoteMediator.MediatorResult = mediator.load(LoadType.REFRESH, state)
@@ -194,6 +209,6 @@ internal class DealsMediatorTest {
         coVerify(exactly = 1) { pagingDao.clearStorePage(defaultStoreId) }
 
         coVerify(exactly = 1) { pagingDao.insert(eq(newDealPage)) }
-        coVerify(exactly = 1) { dealsDao.addDeals(any()) }
+        coVerify(exactly = 1) { dealsDao.addDealEntities(dealEntity) }
     }
 }

--- a/domain/src/test/java/pm/bam/gamedeals/domain/repositories/games/GamesRepositoryTest.kt
+++ b/domain/src/test/java/pm/bam/gamedeals/domain/repositories/games/GamesRepositoryTest.kt
@@ -3,16 +3,22 @@ package pm.bam.gamedeals.domain.repositories.games
 import androidx.arch.core.executor.testing.InstantTaskExecutorRule
 import io.mockk.coEvery
 import io.mockk.coVerify
+import io.mockk.every
 import io.mockk.just
 import io.mockk.mockk
+import io.mockk.mockkStatic
 import io.mockk.runs
+import io.mockk.unmockkAll
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.runTest
+import org.junit.After
 import org.junit.Assert
 import org.junit.Rule
 import org.junit.Test
 import pm.bam.gamedeals.domain.db.dao.GamesDao
+import pm.bam.gamedeals.domain.db.entities.GameEntity
+import pm.bam.gamedeals.domain.db.entities.toEntity
 import pm.bam.gamedeals.domain.models.Game
 import pm.bam.gamedeals.domain.models.GameDetails
 import pm.bam.gamedeals.domain.source.CheapsharkSource
@@ -28,13 +34,21 @@ class GamesRepositoryTest {
 
     private val impl = GamesRepository(gamesDao, cheapsharkSource)
 
+    @After
+    fun tearDown() {
+        unmockkAll()
+    }
+
     @Test
     fun `observe games with refresh called`() = runTest {
         val game: Game = mockk()
+        val entity: GameEntity = mockk()
+        mockkStatic("pm.bam.gamedeals.domain.db.entities.MappersKt")
+        every { game.toEntity() } returns entity
 
         coEvery { gamesDao.observeAllGames() } returns flowOf(emptyList())
         coEvery { cheapsharkSource.fetchGames("") } returns listOf(game)
-        coEvery { gamesDao.addGames(game) } just runs
+        coEvery { gamesDao.addGameEntities(entity) } just runs
 
 
         val result = impl.observeGames().first()
@@ -42,7 +56,7 @@ class GamesRepositoryTest {
 
         coVerify(exactly = 1) { gamesDao.observeAllGames() }
         coVerify(exactly = 1) { cheapsharkSource.fetchGames("") }
-        coVerify(exactly = 1) { gamesDao.addGames(game) }
+        coVerify(exactly = 1) { gamesDao.addGameEntities(entity) }
     }
 
 
@@ -65,15 +79,18 @@ class GamesRepositoryTest {
     @Test
     fun `refresh games`() = runTest {
         val game: Game = mockk()
+        val entity: GameEntity = mockk()
+        mockkStatic("pm.bam.gamedeals.domain.db.entities.MappersKt")
+        every { game.toEntity() } returns entity
 
         coEvery { cheapsharkSource.fetchGames("") } returns listOf(game)
-        coEvery { gamesDao.addGames(game) } just runs
+        coEvery { gamesDao.addGameEntities(entity) } just runs
 
 
         impl.refreshGames()
 
         coVerify(exactly = 1) { cheapsharkSource.fetchGames("") }
-        coVerify(exactly = 1) { gamesDao.addGames(game) }
+        coVerify(exactly = 1) { gamesDao.addGameEntities(entity) }
     }
 
 }

--- a/domain/src/test/java/pm/bam/gamedeals/domain/repositories/giveaway/GiveawaysRepositoryTest.kt
+++ b/domain/src/test/java/pm/bam/gamedeals/domain/repositories/giveaway/GiveawaysRepositoryTest.kt
@@ -7,16 +7,21 @@ import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.just
 import io.mockk.mockk
+import io.mockk.mockkStatic
+import io.mockk.unmockkAll
 import io.mockk.verify
 import kotlinx.collections.immutable.persistentListOf
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.runTest
+import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Rule
 import org.junit.Test
 import pm.bam.gamedeals.domain.db.dao.GiveawaysDao
+import pm.bam.gamedeals.domain.db.entities.GiveawayEntity
+import pm.bam.gamedeals.domain.db.entities.toEntity
 import pm.bam.gamedeals.domain.models.Giveaway
 import pm.bam.gamedeals.domain.models.GiveawayPlatform
 import pm.bam.gamedeals.domain.models.GiveawaySearchParameters
@@ -39,6 +44,11 @@ class GiveawaysRepositoryTest {
     private val gamerPowerSource: GamerPowerSource = mockk()
 
     private val impl = GiveawaysRepository(logger, giveawaysDao, gamerPowerSource)
+
+    @After
+    fun tearDown() {
+        unmockkAll()
+    }
 
     @Test
     fun `observe giveaways with descending publishedDate order`() = runTest {
@@ -63,14 +73,17 @@ class GiveawaysRepositoryTest {
     @Test
     fun `refresh giveaways`() = runTest {
         val giveaway = mockk<Giveaway>()
+        val entity = mockk<GiveawayEntity>()
+        mockkStatic("pm.bam.gamedeals.domain.db.entities.MappersKt")
+        every { giveaway.toEntity() } returns entity
 
         coEvery { gamerPowerSource.fetchGiveaways() } returns listOf(giveaway)
-        coEvery { giveawaysDao.addGiveaways(any()) } just Runs
+        coEvery { giveawaysDao.addGiveawayEntities(any()) } just Runs
 
         impl.refreshGiveaways()
 
         coVerify(exactly = 1) { gamerPowerSource.fetchGiveaways() }
-        coVerify(exactly = 1) { giveawaysDao.addGiveaways(any()) }
+        coVerify(exactly = 1) { giveawaysDao.addGiveawayEntities(entity) }
     }
 
     @Test

--- a/domain/src/test/java/pm/bam/gamedeals/domain/repositories/releases/ReleasesRepositoryTest.kt
+++ b/domain/src/test/java/pm/bam/gamedeals/domain/repositories/releases/ReleasesRepositoryTest.kt
@@ -4,15 +4,21 @@ import androidx.arch.core.executor.testing.InstantTaskExecutorRule
 import io.mockk.Runs
 import io.mockk.coEvery
 import io.mockk.coVerify
+import io.mockk.every
 import io.mockk.just
 import io.mockk.mockk
+import io.mockk.mockkStatic
+import io.mockk.unmockkAll
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.runTest
+import org.junit.After
 import org.junit.Assert
 import org.junit.Rule
 import org.junit.Test
 import pm.bam.gamedeals.domain.db.dao.ReleasesDao
+import pm.bam.gamedeals.domain.db.entities.ReleaseEntity
+import pm.bam.gamedeals.domain.db.entities.toEntity
 import pm.bam.gamedeals.domain.models.Release
 import pm.bam.gamedeals.domain.source.CheapsharkSource
 import pm.bam.gamedeals.logging.Logger
@@ -31,13 +37,21 @@ class ReleasesRepositoryTest {
 
     private val impl = ReleasesRepository(logger, releasesDao, cheapsharkSource)
 
+    @After
+    fun tearDown() {
+        unmockkAll()
+    }
+
     @Test
     fun `observe stores with refresh called`() = runTest {
         val release: Release = mockk()
+        val entity: ReleaseEntity = mockk()
+        mockkStatic("pm.bam.gamedeals.domain.db.entities.MappersKt")
+        every { release.toEntity() } returns entity
 
         coEvery { releasesDao.observeAllReleases() } returns flowOf(listOf(release))
         coEvery { cheapsharkSource.fetchReleases() } returns listOf(release)
-        coEvery { releasesDao.addReleases(any()) } just Runs
+        coEvery { releasesDao.addReleaseEntities(any()) } just Runs
 
 
         val result = impl.observeReleases().first()
@@ -45,22 +59,25 @@ class ReleasesRepositoryTest {
 
         coVerify(exactly = 1) { releasesDao.observeAllReleases() }
         coVerify(exactly = 1) { cheapsharkSource.fetchReleases() }
-        coVerify(exactly = 1) { releasesDao.addReleases(release) }
+        coVerify(exactly = 1) { releasesDao.addReleaseEntities(entity) }
     }
 
 
     @Test
     fun `refresh deals`() = runTest {
         val release: Release = mockk()
+        val entity: ReleaseEntity = mockk()
+        mockkStatic("pm.bam.gamedeals.domain.db.entities.MappersKt")
+        every { release.toEntity() } returns entity
 
         coEvery { cheapsharkSource.fetchReleases() } returns listOf(release)
-        coEvery { releasesDao.addReleases(any()) } just Runs
+        coEvery { releasesDao.addReleaseEntities(any()) } just Runs
 
 
         impl.refreshReleases()
 
         coVerify(exactly = 0) { releasesDao.observeAllReleases() }
         coVerify(exactly = 1) { cheapsharkSource.fetchReleases() }
-        coVerify(exactly = 1) { releasesDao.addReleases(release) }
+        coVerify(exactly = 1) { releasesDao.addReleaseEntities(entity) }
     }
 }

--- a/domain/src/test/java/pm/bam/gamedeals/domain/repositories/stores/StoresRepositoryTest.kt
+++ b/domain/src/test/java/pm/bam/gamedeals/domain/repositories/stores/StoresRepositoryTest.kt
@@ -6,16 +6,21 @@ import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.just
 import io.mockk.mockk
+import io.mockk.mockkStatic
 import io.mockk.runs
+import io.mockk.unmockkAll
 import io.mockk.verify
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.runTest
+import org.junit.After
 import org.junit.Assert
 import org.junit.Rule
 import org.junit.Test
 import pm.bam.gamedeals.common.time.Clock
 import pm.bam.gamedeals.domain.db.dao.StoresDao
+import pm.bam.gamedeals.domain.db.entities.StoreEntity
+import pm.bam.gamedeals.domain.db.entities.toEntity
 import pm.bam.gamedeals.domain.models.Store
 import pm.bam.gamedeals.domain.source.CheapsharkSource
 import pm.bam.gamedeals.domain.utils.millisInHour
@@ -38,13 +43,18 @@ class StoresRepositoryTest {
 
     private val impl = StoresRepository(logger, storesDao, cheapsharkSource, clock)
 
+    @After
+    fun tearDown() {
+        unmockkAll()
+    }
+
 
     @Test
     fun `observe stores - fresh cache - does not refresh`() = runTest {
-        val fresh: Store = mockk { every { expires } returns now + 10_000 }
+        val fresh: StoreEntity = mockk { every { expires } returns now + 10_000 }
 
         coEvery { storesDao.observeAllStores() } returns flowOf(emptyList())
-        coEvery { storesDao.getAllStores() } returns listOf(fresh)
+        coEvery { storesDao.getAllStoreEntities() } returns listOf(fresh)
 
 
         val result = impl.observeStores().first()
@@ -52,64 +62,66 @@ class StoresRepositoryTest {
 
         coVerify(exactly = 0) { cheapsharkSource.fetchStores() }
         coVerify(exactly = 1) { storesDao.observeAllStores() }
-        coVerify(exactly = 1) { storesDao.getAllStores() }
-        coVerify(exactly = 0) { storesDao.addStores(*anyVararg()) }
+        coVerify(exactly = 1) { storesDao.getAllStoreEntities() }
+        coVerify(exactly = 0) { storesDao.addStoreEntities(*anyVararg()) }
     }
 
 
     @Test
     fun `refresh stores - unforced - expired entry - fetches and stamps expires`() = runTest {
-        val expired: Store = mockk { every { expires } returns now - 1 }
+        val expired: StoreEntity = mockk { every { expires } returns now - 1 }
         val fetched: Store = mockk()
-        val stamped: Store = mockk()
-        every { fetched.copy(expires = now + millisInHour * 8) } returns stamped
+        val stamped: StoreEntity = mockk()
+        mockkStatic("pm.bam.gamedeals.domain.db.entities.MappersKt")
+        every { fetched.toEntity(expiresAt = now + millisInHour * 8) } returns stamped
 
         coEvery { cheapsharkSource.fetchStores() } returns listOf(fetched)
-        coEvery { storesDao.getAllStores() } returns listOf(expired)
-        coEvery { storesDao.addStores(*anyVararg()) } just runs
+        coEvery { storesDao.getAllStoreEntities() } returns listOf(expired)
+        coEvery { storesDao.addStoreEntities(*anyVararg()) } just runs
 
 
         impl.refreshStores()
 
 
         coVerify(exactly = 1) { cheapsharkSource.fetchStores() }
-        coVerify(exactly = 1) { storesDao.getAllStores() }
-        coVerify(exactly = 1) { storesDao.addStores(stamped) }
-        verify(exactly = 1) { fetched.copy(expires = now + millisInHour * 8) }
+        coVerify(exactly = 1) { storesDao.getAllStoreEntities() }
+        coVerify(exactly = 1) { storesDao.addStoreEntities(stamped) }
+        verify(exactly = 1) { fetched.toEntity(expiresAt = now + millisInHour * 8) }
     }
 
 
     @Test
     fun `refresh stores - unforced - all fresh - skips fetch`() = runTest {
-        val fresh: Store = mockk { every { expires } returns now + 10_000 }
+        val fresh: StoreEntity = mockk { every { expires } returns now + 10_000 }
 
-        coEvery { storesDao.getAllStores() } returns listOf(fresh)
+        coEvery { storesDao.getAllStoreEntities() } returns listOf(fresh)
 
 
         impl.refreshStores()
 
 
         coVerify(exactly = 0) { cheapsharkSource.fetchStores() }
-        coVerify(exactly = 1) { storesDao.getAllStores() }
-        coVerify(exactly = 0) { storesDao.addStores(*anyVararg()) }
+        coVerify(exactly = 1) { storesDao.getAllStoreEntities() }
+        coVerify(exactly = 0) { storesDao.addStoreEntities(*anyVararg()) }
     }
 
 
     @Test
     fun `refresh stores - forced - skips freshness check and stamps expires`() = runTest {
         val fetched: Store = mockk()
-        val stamped: Store = mockk()
-        every { fetched.copy(expires = now + millisInHour * 8) } returns stamped
+        val stamped: StoreEntity = mockk()
+        mockkStatic("pm.bam.gamedeals.domain.db.entities.MappersKt")
+        every { fetched.toEntity(expiresAt = now + millisInHour * 8) } returns stamped
 
         coEvery { cheapsharkSource.fetchStores() } returns listOf(fetched)
-        coEvery { storesDao.addStores(*anyVararg()) } just runs
+        coEvery { storesDao.addStoreEntities(*anyVararg()) } just runs
 
 
         impl.refreshStores(force = true)
 
 
         coVerify(exactly = 1) { cheapsharkSource.fetchStores() }
-        coVerify(exactly = 0) { storesDao.getAllStores() }
-        coVerify(exactly = 1) { storesDao.addStores(stamped) }
+        coVerify(exactly = 0) { storesDao.getAllStoreEntities() }
+        coVerify(exactly = 1) { storesDao.addStoreEntities(stamped) }
     }
 }


### PR DESCRIPTION
## Summary

- Move Room schema (`@Entity`, `@PrimaryKey`, `expires`) off the public domain models into a new internal `domain/db/entities/` package, with write-side `Mappers.kt` (`Deal.toEntity()` etc.).
- DAOs now project public columns back to public types via Room's name-based constructor mapping — reads return `Deal`/`Store`/etc., writes take `*Entity`. Cache reads use new `getStoreDealEntities` / `getAllStoreEntities` paths.
- Schema version (3) and table names (`Deal`, `Store`, ...) unchanged — purely a code-layout split, no migration needed.

## Test plan

- [x] `:domain:testDebugUnitTest` — green (test files updated to `mockkStatic("...MappersKt")` + return `*Entity` from cache mocks)
- [x] `assembleDebug` — green
- [x] Full `testDebugUnitTest` across all modules — green
- [ ] Manual smoke on existing v3 DB after install (no schema change, but worth confirming reads still hydrate)

🤖 Generated with [Claude Code](https://claude.com/claude-code)