### PR TITLE
fix(#98): annotate Giveaway @Immutable to match sibling domain models

### DIFF
--- a/domain/src/main/java/pm/bam/gamedeals/domain/models/Giveaway.kt
+++ b/domain/src/main/java/pm/bam/gamedeals/domain/models/Giveaway.kt
@@ -13,6 +13,7 @@ import kotlinx.serialization.properties.Properties
 import pm.bam.gamedeals.domain.utils.LocalDateSerializer
 import java.time.LocalDateTime
 
+@Immutable
 @Entity(tableName = "Giveaway")
 @Serializable
 data class Giveaway(


### PR DESCRIPTION
Closes #98.

## Summary

`Giveaway` was the lone domain model in `pm.bam.gamedeals.domain.models` not annotated `@Immutable`, while its siblings (`Deal`, `Store`, `StoreImages`, `GiveawaySearchParameters`, etc.) all are. Because `Giveaway` carries Compose-unstable fields (`platforms: List<GiveawayPlatform>` interface-typed list, `publishedDate: LocalDateTime` outside Compose's stable type set), Compose treats every `Giveaway` parameter as unstable and recomposes any composable that takes one even when the value hasn't changed.

Annotating the class `@Immutable` tells Compose to trust the contents won't change and skip those recompositions. Placement matches `Store.kt` (`@Immutable` above `@Entity` above `@Serializable`); the `@Immutable` import was already present in the file.

The optional `ImmutableList<GiveawayPlatform>` mapper-boundary conversion mentioned in the issue was intentionally skipped — the issue marks it optional, sibling models don't do it, and the `@Immutable` annotation alone is sufficient per the issue's recommendation.

## Test plan

- [ ] `./gradlew :domain:assemble` builds clean
- [ ] `./gradlew :domain:test` passes
- [ ] Spot-check giveaway-row composables for reduced recomposition under Compose layout inspector (manual)

🤖 Generated with [Claude Code](https://claude.com/claude-code)