### PR TITLE
fix(#100): wrap StoreScreen onBack in rememberUpdatedState

### DIFF
--- a/feature/store/src/main/java/pm/bam/gamedeals/feature/store/ui/StoreScreen.kt
+++ b/feature/store/src/main/java/pm/bam/gamedeals/feature/store/ui/StoreScreen.kt
@@ -34,6 +34,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.foundation.layout.wrapContentSize
@@ -79,6 +80,7 @@ internal fun StoreScreen(
 ) {
     val context = LocalContext.current
     val snackbarHostState = remember { SnackbarHostState() }
+    val currentOnBack by rememberUpdatedState(onBack)
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
     val deals: LazyPagingItems<Deal> = viewModel.deals.collectAsLazyPagingItems()
     val dealDetails by viewModel.dealDetails.collectAsStateWithLifecycle()
@@ -116,7 +118,7 @@ internal fun StoreScreen(
                 actionLabel = context.getString(R.string.store_screen_data_loading_error_retry)
             )
             if (results == SnackbarResult.ActionPerformed) {
-                onBack()
+                currentOnBack()
             }
         }
 


### PR DESCRIPTION
Closes #100.

## Summary
- `StoreScreen` forwarded `onBack` directly into a `LaunchedEffect(snackbarHostState)` that fired it on the error-snackbar Retry action, capturing the callback by closure without `rememberUpdatedState` and risking a stale reference.
- Introduces `val currentOnBack by rememberUpdatedState(onBack)` and invokes `currentOnBack()` from inside the effect, matching the pattern used in `HomeScreen`, `GameScreen`, `GiveawaysScreen`, and `SearchScreen`.

## Test plan
- [x] `:feature:store:testDebugUnitTest` passes
- [x] `:feature:store:lintDebug` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)