### PR TITLE
fix(#96): handle missing release game via terminal .catch + null-as-not-found

### DIFF
--- a/feature/home/src/main/java/pm/bam/gamedeals/feature/home/ui/HomeViewModel.kt
+++ b/feature/home/src/main/java/pm/bam/gamedeals/feature/home/ui/HomeViewModel.kt
@@ -24,7 +24,6 @@ import kotlinx.coroutines.flow.emitAll
 import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.map
-import kotlinx.coroutines.flow.onCompletion
 import kotlinx.coroutines.flow.onStart
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
@@ -92,15 +91,16 @@ internal class HomeViewModel @Inject constructor(
         viewModelScope.launch {
             flow { emit(gamesRepository.getReleaseGameId(releaseTitle)) }
                 .onStart { _uiState.update { it.copy(state = HomeScreenStatus.LOADING) } }
-                .map { gameId -> gameId ?: throw IllegalStateException("Game not found") }
                 .onError { fatal(logger, it) }
-                .onCompletion {
-                    when (it == null) {
-                        true -> _uiState.update { current -> current.copy(state = HomeScreenStatus.SUCCESS) }
-                        else -> _uiState.update { current -> current.copy(state = HomeScreenStatus.ERROR) }
+                .catch { _uiState.update { current -> current.copy(state = HomeScreenStatus.ERROR) } }
+                .collect { gameId ->
+                    if (gameId == null) {
+                        _uiState.update { current -> current.copy(state = HomeScreenStatus.ERROR) }
+                    } else {
+                        _uiState.update { current -> current.copy(state = HomeScreenStatus.SUCCESS) }
+                        _events.emit(HomeUiEvent.NavigateToGame(gameId))
                     }
                 }
-                .collect { _events.emit(HomeUiEvent.NavigateToGame(it)) }
         }
 
     fun loadDealDetails(dealId: String, dealStoreId: Int, dealTitle: String, dealPriceDenominated: String) {

--- a/feature/home/src/test/java/pm/bam/gamedeals/feature/home/ui/HomeViewModelTest.kt
+++ b/feature/home/src/test/java/pm/bam/gamedeals/feature/home/ui/HomeViewModelTest.kt
@@ -30,7 +30,6 @@ import pm.bam.gamedeals.feature.home.ui.HomeViewModel.HomeScreenStatus
 import pm.bam.gamedeals.testing.MainCoroutineRule
 import pm.bam.gamedeals.testing.TestingLoggingListener
 import pm.bam.gamedeals.testing.utils.observeEmissions
-import pm.bam.gamedeals.testing.utils.second
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class HomeViewModelTest {
@@ -150,8 +149,8 @@ class HomeViewModelTest {
         coVerify(exactly = 1) { gamesRepository.getReleaseGameId(releaseTitle) }
     }
 
-    @Test(expected = Exception::class)
-    fun `onReleaseGame title exception`() = runTest {
+    @Test
+    fun `onReleaseGame title exception surfaces ERROR without crashing`() = runTest {
         val releaseTitle = "title"
 
         coEvery { storesRepository.observeStores() } returns flowOf(listOf())
@@ -166,9 +165,31 @@ class HomeViewModelTest {
 
         viewModel.onReleaseGame(releaseTitle)
 
-        assertEquals(2, emissions.size)
-        assertNotNull(emissions.second())
-        assertEquals(HomeScreenData(state = HomeScreenStatus.ERROR), emissions.second())
+        assertEquals(HomeScreenData(state = HomeScreenStatus.ERROR), emissions.last())
+
+        assertNull(events.firstOrNull())
+
+        coVerify(exactly = 1) { storesRepository.observeStores() }
+        coVerify(exactly = 1) { gamesRepository.getReleaseGameId(releaseTitle) }
+    }
+
+    @Test
+    fun `onReleaseGame missing game surfaces ERROR without crashing`() = runTest {
+        val releaseTitle = "title"
+
+        coEvery { storesRepository.observeStores() } returns flowOf(listOf())
+        coEvery { releasesRepository.observeReleases() } returns flowOf(listOf())
+        coEvery { giveawaysRepository.observeGiveaways() } returns flowOf(listOf())
+        coEvery { giveawaysRepository.refreshGiveaways() } returns Unit
+        coEvery { gamesRepository.getReleaseGameId(releaseTitle) } returns null
+
+        viewModel = HomeViewModel(storesRepository, dealsRepository, gamesRepository, releasesRepository, giveawaysRepository, logger)
+        val emissions = observeStates()
+        val events = viewModel.events.observeEmissions(this.backgroundScope, mainCoroutineRule.testDispatcher)
+
+        viewModel.onReleaseGame(releaseTitle)
+
+        assertEquals(HomeScreenData(state = HomeScreenStatus.ERROR), emissions.last())
 
         assertNull(events.firstOrNull())
 


### PR DESCRIPTION
Closes #96.

## Summary
- `HomeViewModel.onReleaseGame` previously threw `IllegalStateException("Game not found")` inside `.map` when `getReleaseGameId` returned `null`, then relied on the project's `Flow.onError` extension (which rethrows) and `.onCompletion` to translate it to ERROR state. Because `.onCompletion` does not consume the exception, it propagated out of `viewModelScope.launch` and crashed the app on any "new release" the CheapShark deals API didn't return as an exact-title match.
- Per L-2026-04-30-04, the function stays Flow-shaped: kept `.onStart`, kept the `.onError { fatal(logger, it) }` log-and-rethrow, but replaced the trailing `.onCompletion` with a terminal `.catch` that updates `_uiState` to ERROR without rethrowing. `null` is now treated as a normal "not found" outcome — collected, mapped to ERROR state, no `NavigateToGame` event emitted. No `runCatching { ... }` wrap.
- Updated `HomeViewModelTest` to assert the new contract: the prior `@Test(expected = Exception::class)` test is replaced with one that asserts ERROR state surfaces and no event fires; a new `onReleaseGame missing game surfaces ERROR without crashing` test exercises the null branch; the success path test is unchanged.

## Test plan
- [x] `./gradlew :feature:home:testDebugUnitTest --tests "pm.bam.gamedeals.feature.home.ui.HomeViewModelTest"` — 7 tests pass, 0 failures (run under JBR 21 per L-2026-04-30-02 / `reference_local_jdk_for_app_assemble`).
- [ ] Manual smoke: tap a "new release" tile whose title is not an exact match in the deals index — should land on the home screen ERROR state instead of crashing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)