### PR TITLE
fix(#97): move .catch inside flatMapLatest/combine to keep collector alive

### DIFF
--- a/feature/giveaways/src/main/java/pm/bam/gamedeals/feature/giveaways/ui/GiveawaysViewModel.kt
+++ b/feature/giveaways/src/main/java/pm/bam/gamedeals/feature/giveaways/ui/GiveawaysViewModel.kt
@@ -44,8 +44,12 @@ internal class GiveawaysViewModel @Inject constructor(
         viewModelScope.launch {
             val giveawaysFlow = parametersFlow
                 .flatMapLatest { params ->
-                    if (params == null) flow { emitAll(giveawaysRepository.observeGiveaways()) }
+                    val source = if (params == null) flow { emitAll(giveawaysRepository.observeGiveaways()) }
                     else flow { emitAll(giveawaysRepository.observeGiveaways(params)) }
+                    source.catch {
+                        refreshOutcomeFlow.value = RefreshOutcome.Error
+                        emit(emptyList())
+                    }
                 }
 
             combine(giveawaysFlow, refreshOutcomeFlow) { giveaways, outcome ->
@@ -61,7 +65,6 @@ internal class GiveawaysViewModel @Inject constructor(
                 }
             }
                 .logFlow(logger)
-                .catch { _uiState.update { current -> current.copy(status = GiveawaysScreenStatus.ERROR) } }
                 .collect { newState -> _uiState.emit(newState) }
         }
     }

--- a/feature/giveaways/src/test/java/pm/bam/gamedeals/feature/giveaways/ui/GiveawaysViewModelTest.kt
+++ b/feature/giveaways/src/test/java/pm/bam/gamedeals/feature/giveaways/ui/GiveawaysViewModelTest.kt
@@ -179,6 +179,34 @@ class GiveawaysViewModelTest {
     }
 
     @Test
+    fun `upstream collector survives an observeGiveaways failure and processes later emissions`() = runTest {
+        val giveaway = mockk<Giveaway>()
+        val filteredRoom = MutableSharedFlow<List<Giveaway>>(replay = 1)
+        coEvery { giveawaysRepository.observeGiveaways() } throws Exception()
+        coEvery { giveawaysRepository.observeGiveaways(any()) } returns filteredRoom
+
+        val viewModel = GiveawaysViewModel(TestingLoggingListener(), giveawaysRepository)
+
+        val emissions = observeStates(viewModel)
+        // The init-time failure must be surfaced as ERROR but must NOT terminate the collector.
+        Assert.assertEquals(GiveawaysViewModel.GiveawaysScreenStatus.ERROR, emissions.last().status)
+
+        // Switching params re-subscribes flatMapLatest. If the outer collector had died (the bug
+        // this fix targets), the new upstream value would never reach _uiState and giveaways
+        // would stay empty.
+        val para = GiveawaySearchParameters(
+            types = persistentListOf(GiveawayType.GAME to true),
+            platforms = persistentListOf(GiveawayPlatform.PC to true),
+            sortBy = GiveawaySortBy.DATE
+        )
+        viewModel.loadGiveaway(para)
+        filteredRoom.emit(listOf(giveaway))
+
+        Assert.assertEquals(1, emissions.last().giveaways.size)
+        Assert.assertEquals(giveaway, emissions.last().giveaways.first())
+    }
+
+    @Test
     fun `load Giveaways cancels prior unfiltered collector when filter applied`() = runTest {
         val unfilteredOne = mockk<Giveaway>()
         val unfilteredTwo = mockk<Giveaway>()

--- a/feature/search/src/main/java/pm/bam/gamedeals/feature/search/ui/SearchViewModel.kt
+++ b/feature/search/src/main/java/pm/bam/gamedeals/feature/search/ui/SearchViewModel.kt
@@ -59,10 +59,10 @@ internal class SearchViewModel @Inject constructor(
                                     false -> SearchData.SearchResults(it.toImmutableList())
                                 }
                             }
+                            .catch { emit(SearchData.Error) }
                     }
                 }
                 .logFlow(logger)
-                .catch { emit(SearchData.Error) }
                 .collect { _resultState.emit(it) }
         }
     }

--- a/feature/search/src/test/java/pm/bam/gamedeals/feature/search/ui/SearchViewModelTest.kt
+++ b/feature/search/src/test/java/pm/bam/gamedeals/feature/search/ui/SearchViewModelTest.kt
@@ -110,6 +110,28 @@ class SearchViewModelTest {
         assertEquals(SearchData.Error, emissions.third())
     }
 
+    @Test
+    fun `subsequent search after error still produces results`() = runTest {
+        val deal: Deal = mockk()
+        val deals = listOf(deal)
+
+        coEvery { gamesRepository.searchGames(searchParameters = any()) } throws Exception() andThen deals
+
+        val emissions = observeStates()
+        assertEquals(1, emissions.size)
+        assertEquals(SearchData.Empty, emissions.first())
+
+        // First search fails — the upstream collector must survive the error.
+        viewModel.searchGames(title = "First")
+        delay(1200)
+        assertEquals(SearchData.Error, emissions.last())
+
+        // Second search after the error should still drive the upstream collector.
+        viewModel.searchGames(title = "Second")
+        delay(1200)
+        assertEquals(SearchData.SearchResults(deals.toImmutableList()), emissions.last())
+    }
+
 
     private fun TestScope.observeStates() = viewModel.resultState.observeEmissions(this.backgroundScope, mainCoroutineRule.testDispatcher)
 }


### PR DESCRIPTION
Closes #97.

## Summary
`SearchViewModel` and `GiveawaysViewModel` each have a long-lived collector that wraps a `flatMapLatest` (Search) or `combine(...)` (Giveaways) source-of-truth flow. Both ended in an outer-chain `.catch` that swallowed errors and emitted an `Error`/`ERROR` state — but `.catch` then completes, the collector returns, and the upstream `MutableSharedFlow` / `MutableStateFlow` is left with no listener. Subsequent `searchGames(...)` / `loadGiveaway(...)` / `reloadGiveaways()` calls produced no observable state change for the rest of the VM lifetime.

The fix pushes the `.catch` *inside* the `flatMapLatest` lambda for each VM so the inner flow handles its own failure and the outer collector keeps running. This matches the working pattern already in `GameViewModel.loadGameDetailsFlow`.

### `feature/search/.../SearchViewModel.kt`
Moved `.catch { emit(SearchData.Error) }` from the outer chain into the `else ->` branch of the inner `flatMapLatest { ... }` so an exception thrown by `gamesRepository.searchGames(...)` only terminates the inner per-query flow. The outer collector subscribed to `searchParametersFlow` survives, so a follow-up `searchGames(...)` still propagates.

### `feature/giveaways/.../GiveawaysViewModel.kt`
Removed the outer `.catch { _uiState.update { ... ERROR } }` after `combine(giveawaysFlow, refreshOutcomeFlow)`. The `giveawaysFlow` (built inside `flatMapLatest { params -> ... }`) now catches its own failure: it sets `refreshOutcomeFlow.value = RefreshOutcome.Error` and emits an empty list, so `combine` re-fires into the existing `RefreshOutcome.Error → GiveawaysScreenStatus.ERROR` mapper and the outer collector keeps listening. Subsequent param changes / Room invalidations now reach `_uiState` as expected.

## Tests
- `feature/search/.../SearchViewModelTest.kt` — added `subsequent search after error still produces results`: first search throws and emits `Error`, second search returns deals and must still flip `_resultState` to `SearchResults`. Would fail under the old code (collector dead after first error).
- `feature/giveaways/.../GiveawaysViewModelTest.kt` — added `upstream collector survives an observeGiveaways failure and processes later emissions`: `observeGiveaways()` throws on first subscribe, then a `loadGiveaway(params)` re-subscribes via the filtered Room flow and emits one giveaway. Would fail under the old code (collector exits after the init failure, never processes the filtered emission).

## Test plan
- [x] `:feature:search:testDebugUnitTest` — green (existing + new test)
- [x] `:feature:giveaways:testDebugUnitTest` — green (existing + new test)
- [x] `:feature:search:lintDebug` and `:feature:giveaways:lintDebug` — green

🤖 Generated with [Claude Code](https://claude.com/claude-code)