### PR TITLE
fix(#101): clear WebView loading on main-frame errors

### DIFF
--- a/feature/webview/build.gradle.kts
+++ b/feature/webview/build.gradle.kts
@@ -36,4 +36,5 @@ dependencies {
     androidTestImplementation(libs.androidx.espresso.core)
     androidTestImplementation(libs.androidx.compose.junit4)
     androidTestImplementation(libs.mockk.android)
+    debugImplementation(libs.androidx.compose.test)
 }

--- a/feature/webview/src/androidTest/java/pm/bam/gamedeals/feature/webview/ui/WebViewTest.kt
+++ b/feature/webview/src/androidTest/java/pm/bam/gamedeals/feature/webview/ui/WebViewTest.kt
@@ -1,15 +1,29 @@
 package pm.bam.gamedeals.feature.webview.ui
 
+import android.view.View
+import android.webkit.WebResourceError
+import android.webkit.WebResourceRequest
+import android.webkit.WebResourceResponse
+import android.webkit.WebView
+import android.webkit.WebViewClient
 import androidx.compose.ui.platform.LocalUriHandler
 import androidx.compose.ui.platform.UriHandler
+import androidx.compose.ui.semantics.SemanticsProperties
+import androidx.compose.ui.test.SemanticsMatcher
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
+import androidx.test.espresso.Espresso.onView
+import androidx.test.espresso.UiController
+import androidx.test.espresso.ViewAction
+import androidx.test.espresso.matcher.ViewMatchers.isAssignableFrom
 import androidx.test.platform.app.InstrumentationRegistry
+import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
+import org.hamcrest.Matcher
 import org.junit.Rule
 import org.junit.Test
 import pm.bam.gamedeals.feature.webview.R
@@ -66,5 +80,112 @@ class WebViewTest {
 
         // Verify URI handler was called
         verify { uriHandler.openUri(url) }
+    }
+
+    @Test
+    fun webView_clearsLoadingOnMainFrameReceivedError() {
+        composeTestRule.setContent {
+            WebView(
+                gameTitle = "Test Game",
+                url = "https://example.com",
+                onBack = {}
+            )
+        }
+
+        // The spinner is initially displayed because `loading` defaults to true.
+        composeTestRule.onNode(SemanticsMatcher.keyIsDefined(SemanticsProperties.ProgressBarRangeInfo))
+            .assertIsDisplayed()
+
+        val mainFrameRequest = mockk<WebResourceRequest> {
+            every { isForMainFrame } returns true
+        }
+        val error = mockk<WebResourceError>(relaxed = true)
+
+        invokeOnWebViewClient { client, view ->
+            client.onReceivedError(view, mainFrameRequest, error)
+        }
+
+        composeTestRule.waitForIdle()
+
+        composeTestRule.onNode(SemanticsMatcher.keyIsDefined(SemanticsProperties.ProgressBarRangeInfo))
+            .assertDoesNotExist()
+    }
+
+    @Test
+    fun webView_clearsLoadingOnMainFrameReceivedHttpError() {
+        composeTestRule.setContent {
+            WebView(
+                gameTitle = "Test Game",
+                url = "https://example.com",
+                onBack = {}
+            )
+        }
+
+        composeTestRule.onNode(SemanticsMatcher.keyIsDefined(SemanticsProperties.ProgressBarRangeInfo))
+            .assertIsDisplayed()
+
+        val mainFrameRequest = mockk<WebResourceRequest> {
+            every { isForMainFrame } returns true
+        }
+        val errorResponse = mockk<WebResourceResponse>(relaxed = true)
+
+        invokeOnWebViewClient { client, view ->
+            client.onReceivedHttpError(view, mainFrameRequest, errorResponse)
+        }
+
+        composeTestRule.waitForIdle()
+
+        composeTestRule.onNode(SemanticsMatcher.keyIsDefined(SemanticsProperties.ProgressBarRangeInfo))
+            .assertDoesNotExist()
+    }
+
+    @Test
+    fun webView_keepsLoadingOnSubFrameReceivedError() {
+        composeTestRule.setContent {
+            WebView(
+                gameTitle = "Test Game",
+                url = "https://example.com",
+                onBack = {}
+            )
+        }
+
+        composeTestRule.onNode(SemanticsMatcher.keyIsDefined(SemanticsProperties.ProgressBarRangeInfo))
+            .assertIsDisplayed()
+
+        val subFrameRequest = mockk<WebResourceRequest> {
+            every { isForMainFrame } returns false
+        }
+        val error = mockk<WebResourceError>(relaxed = true)
+        val errorResponse = mockk<WebResourceResponse>(relaxed = true)
+
+        invokeOnWebViewClient { client, view ->
+            client.onReceivedError(view, subFrameRequest, error)
+            client.onReceivedHttpError(view, subFrameRequest, errorResponse)
+        }
+
+        composeTestRule.waitForIdle()
+
+        // Sub-frame failures must not kill the spinner.
+        composeTestRule.onNode(SemanticsMatcher.keyIsDefined(SemanticsProperties.ProgressBarRangeInfo))
+            .assertIsDisplayed()
+    }
+
+    /**
+     * Locates the [WebView] inside the composed tree via Espresso and invokes the supplied
+     * action against its [WebViewClient]. The action runs on the main thread, which is the
+     * same thread that the real WebView would use to deliver these callbacks.
+     */
+    private fun invokeOnWebViewClient(action: (WebViewClient, WebView) -> Unit) {
+        onView(isAssignableFrom(WebView::class.java)).perform(object : ViewAction {
+            override fun getConstraints(): Matcher<View> = isAssignableFrom(WebView::class.java)
+
+            override fun getDescription(): String = "Invoke a WebViewClient callback"
+
+            override fun perform(uiController: UiController, view: View) {
+                val webView = view as WebView
+                action(webView.webViewClient, webView)
+                uiController.loopMainThreadUntilIdle()
+            }
+        })
     }
 }

--- a/feature/webview/src/main/java/pm/bam/gamedeals/feature/webview/ui/WebView.kt
+++ b/feature/webview/src/main/java/pm/bam/gamedeals/feature/webview/ui/WebView.kt
@@ -3,7 +3,9 @@ package pm.bam.gamedeals.feature.webview.ui
 import android.annotation.SuppressLint
 import android.graphics.Bitmap
 import android.view.ViewGroup
+import android.webkit.WebResourceError
 import android.webkit.WebResourceRequest
+import android.webkit.WebResourceResponse
 import android.webkit.WebView
 import android.webkit.WebViewClient
 import androidx.compose.foundation.layout.PaddingValues
@@ -97,6 +99,16 @@ internal fun WebView(
                         override fun onPageFinished(view: WebView?, url: String?) {
                             super.onPageFinished(view, url)
                             loading = false
+                        }
+
+                        override fun onReceivedError(view: WebView?, request: WebResourceRequest?, error: WebResourceError?) {
+                            super.onReceivedError(view, request, error)
+                            if (request?.isForMainFrame == true) loading = false
+                        }
+
+                        override fun onReceivedHttpError(view: WebView?, request: WebResourceRequest?, errorResponse: WebResourceResponse?) {
+                            super.onReceivedHttpError(view, request, errorResponse)
+                            if (request?.isForMainFrame == true) loading = false
                         }
                     }
                 }


### PR DESCRIPTION
Closes #101.

## Summary

The embedded `WebViewClient` set `loading = true` in `shouldOverrideUrlLoading`/`onPageStarted` but only cleared it in `onPageFinished`. If a navigation failed (network error, abort during `onRelease`'s `loadUrl("about:blank")`, certain redirect chains) `onPageFinished` never fired and the top-bar spinner stayed pinned until the user navigated away.

This PR overrides `onReceivedError` and `onReceivedHttpError` and clears `loading` only when the failing request is for the main frame — sub-frame failures (third-party iframes, ad slots) intentionally do not stop the spinner.

## Files changed

- `feature/webview/src/main/java/pm/bam/gamedeals/feature/webview/ui/WebView.kt` — added the two overrides.
- `feature/webview/src/androidTest/java/pm/bam/gamedeals/feature/webview/ui/WebViewTest.kt` — added three tests that drive the `WebViewClient` callbacks directly via an Espresso `ViewAction` against the hosted `WebView`:
  - `webView_clearsLoadingOnMainFrameReceivedError`
  - `webView_clearsLoadingOnMainFrameReceivedHttpError`
  - `webView_keepsLoadingOnSubFrameReceivedError`
- `feature/webview/build.gradle.kts` — added `debugImplementation(libs.androidx.compose.test)` (`ui-test-manifest`). `:feature:webview` does not use the `gamedeals.android.feature` convention plugin (Hilt/Paging/Coil — none used here), so this dep is not inherited; without it `createComposeRule()` has no host activity in the test manifest.

## Things the reviewer should know

- **Test execution.** Unit tests (`:feature:webview:testDebugUnitTest`) — no source, NO-OP, as expected. The instrumentation tests in this module (including the planner's pre-existing `webView_displaysTitleAndHandlesBack` and `webView_handlesOpenInBrowser`) currently fail on a Pixel 5 — 14 device with `IllegalStateException: No compose hierarchies found in the app`. Logcat shows the cause: Android 14 puts up a `DeprecatedTargetSdkVersionDialog` for the `target_sdk_version=26` test apk, which keeps the `ComponentActivity` from being displayed before `setContent` is queried. The same dialog appears for `:feature:search` instrumentation tests too — those just happen to take long enough that the dialog gets dismissed in time. This is environmental, not a regression introduced here, and not something the new tests can fix from inside the test class. Both production code and `androidTest` source compile cleanly.
- **No test-only seam.** The fix exposes nothing new on the production type. The new tests find the `WebView` through Espresso's `isAssignableFrom(WebView::class.java)`, then invoke `webView.webViewClient.onReceivedError(...)` directly — same callback path the platform uses, no reflection, no `@VisibleForTesting`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)