### PR TITLE
fix(#122): rethrow CancellationException in GiveawaysViewModel.reloadGiveaways

### DIFF
--- a/feature/giveaways/src/commonMain/kotlin/pm/bam/gamedeals/feature/giveaways/ui/GiveawaysViewModel.kt
+++ b/feature/giveaways/src/commonMain/kotlin/pm/bam/gamedeals/feature/giveaways/ui/GiveawaysViewModel.kt
@@ -6,6 +6,7 @@ import androidx.lifecycle.viewModelScope
 import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.persistentListOf
 import kotlinx.collections.immutable.toImmutableList
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
@@ -69,6 +70,8 @@ internal class GiveawaysViewModel(
             refreshOutcomeFlow.value = RefreshOutcome.Idle
             try {
                 giveawaysRepository.refreshGiveaways()
+            } catch (e: CancellationException) {
+                throw e
             } catch (_: Throwable) {
                 refreshOutcomeFlow.value = RefreshOutcome.Error
             }

--- a/feature/giveaways/src/commonTest/kotlin/pm/bam/gamedeals/feature/giveaways/ui/GiveawaysViewModelTest.kt
+++ b/feature/giveaways/src/commonTest/kotlin/pm/bam/gamedeals/feature/giveaways/ui/GiveawaysViewModelTest.kt
@@ -11,6 +11,7 @@ import dev.mokkery.everySuspend
 import dev.mokkery.matcher.any
 import dev.mokkery.mock
 import kotlinx.collections.immutable.persistentListOf
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableSharedFlow
@@ -32,6 +33,7 @@ import kotlin.test.AfterTest
 import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertNotEquals
 
 class GiveawaysViewModelTest : MainDispatcherTest() {
 
@@ -126,6 +128,27 @@ class GiveawaysViewModelTest : MainDispatcherTest() {
 
         val emissions = observeStates(viewModel)
         assertEquals(GiveawaysViewModel.GiveawaysScreenStatus.ERROR, emissions.last().status)
+    }
+
+    @Test
+    fun cancelled_reload_does_not_set_ERROR() = runTest {
+        val unfilteredRoom = MutableSharedFlow<List<Giveaway>>(replay = 1)
+        every { giveawaysRepository.observeGiveaways() } returns unfilteredRoom
+        // Simulate an in-flight reload being cancelled (e.g. viewModelScope cleared while
+        // refreshGiveaways() is suspended). The CancellationException must propagate, not be
+        // swallowed into a RefreshOutcome.Error.
+        everySuspend { giveawaysRepository.refreshGiveaways() } throws CancellationException("scope cleared")
+
+        val viewModel = GiveawaysViewModel(TestingLoggingListener(), giveawaysRepository)
+        unfilteredRoom.emit(emptyList())
+
+        viewModel.reloadGiveaways()
+
+        val emissions = observeStates(viewModel)
+        // Pre-fix this would be ERROR (the bare catch swallowed the CE and wrote
+        // RefreshOutcome.Error). After the fix the CE is rethrown and refreshOutcomeFlow
+        // stays Idle, so the surviving status must not be ERROR.
+        assertNotEquals(GiveawaysViewModel.GiveawaysScreenStatus.ERROR, emissions.last().status)
     }
 
     @Test


### PR DESCRIPTION
Closes #122.

`GiveawaysViewModel.reloadGiveaways()` wrapped the suspending `giveawaysRepository.refreshGiveaways()` call in a bare `catch (_: Throwable)`, which also matches `CancellationException`. When `viewModelScope` is cancelled while the refresh is in flight, the CE was swallowed and the catch body wrote `RefreshOutcome.Error`, so a cancelled reload surfaced as a spurious refresh failure on the surviving StateFlow. The fix catches `CancellationException` first and rethrows, restoring cooperative cancellation.

Per `L-2026-05-02-04`, every `catch (Throwable)` block wrapping suspending work in this codebase must rethrow `CancellationException` first. Same antipattern previously fixed in #71 (`DealDetailsController`) and #31 (`DealsMediator`); this was the last outlier.

## Test plan

- [x] `./gradlew :feature:giveaways:compileDebugKotlinAndroid` passes.
- [x] `./gradlew :feature:giveaways:testDebugUnitTest` passes (11/11 tests, including new `cancelled_reload_does_not_set_ERROR`).
- [x] Verified the new test fails on `dev` baseline (status becomes `ERROR`) and passes with the fix applied.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>

Generated with [Claude Code](https://claude.com/claude-code)