### PR TITLE
fix(#123): warm DomainDatabase off-main in Application.onCreate

### DIFF
--- a/app/src/main/java/pm/bam/gamedeals/GameDealsApplication.kt
+++ b/app/src/main/java/pm/bam/gamedeals/GameDealsApplication.kt
@@ -7,12 +7,19 @@ import coil3.ImageLoader
 import coil3.PlatformContext
 import coil3.SingletonImageLoader
 import io.sentry.kotlin.multiplatform.Sentry
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.launch
+import org.koin.android.ext.android.get
 import org.koin.android.ext.android.inject
 import org.koin.android.ext.koin.androidContext
 import org.koin.core.context.startKoin
 import pm.bam.gamedeals.common.di.commonAndroidModule
 import pm.bam.gamedeals.common.di.commonModule
 import pm.bam.gamedeals.di.appModule
+import pm.bam.gamedeals.domain.db.DomainDatabase
 import pm.bam.gamedeals.domain.di.domainAndroidModule
 import pm.bam.gamedeals.domain.di.domainModule
 import pm.bam.gamedeals.feature.game.di.gameModule
@@ -20,7 +27,9 @@ import pm.bam.gamedeals.feature.giveaways.di.giveawaysModule
 import pm.bam.gamedeals.feature.home.di.homeModule
 import pm.bam.gamedeals.feature.search.di.searchModule
 import pm.bam.gamedeals.feature.store.di.storeModule
+import pm.bam.gamedeals.logging.Logger
 import pm.bam.gamedeals.logging.di.loggingAndroidModule
+import pm.bam.gamedeals.logging.error
 import pm.bam.gamedeals.remote.cheapshark.di.cheapsharkNetworkModule
 import pm.bam.gamedeals.remote.cheapshark.di.cheapsharkRemoteModule
 import pm.bam.gamedeals.remote.di.remoteModule
@@ -55,6 +64,7 @@ class GameDealsApplication : Application(), SingletonImageLoader.Factory {
                 storeModule
             )
         }
+        warmDomainDatabase()
         if (isDebuggable()) {
             StrictMode.setThreadPolicy(
                 StrictMode.ThreadPolicy.Builder()
@@ -69,6 +79,39 @@ class GameDealsApplication : Application(), SingletonImageLoader.Factory {
 
     private fun isDebuggable(): Boolean =
         (applicationInfo.flags and ApplicationInfo.FLAG_DEBUGGABLE) != 0
+
+    /**
+     * Resolve [DomainDatabase] from Koin on a background thread. Without this, the
+     * first DAO request — which happens during `HomeScreen`'s composition via
+     * `koinViewModel()` — drives the singleton `RoomDatabase.Builder.build()` call
+     * (and any pending destructive migrations) on the Main thread during the first
+     * frame.
+     *
+     * `:app` doesn't have `androidx.room` on its compile classpath, so we can't dot
+     * into `db.openHelper.writableDatabase` here. Resolving the singleton is enough
+     * to force `.build()` — the actual SQLite connection then opens lazily on the
+     * first DAO query, which already runs on a coroutine dispatcher.
+     *
+     * Fire-and-forget on a [SupervisorJob]-backed [Dispatchers.IO] scope: failures
+     * here must never crash the app, since the regular DAO call path will surface
+     * real errors with their proper context. [CancellationException] is rethrown so
+     * structured concurrency stays honest if the scope is ever cancelled.
+     */
+    private fun warmDomainDatabase() {
+        val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+        scope.launch {
+            try {
+                get<DomainDatabase>()
+            } catch (ce: CancellationException) {
+                throw ce
+            } catch (t: Throwable) {
+                runCatching {
+                    val logger: Logger = get()
+                    error(logger, throwable = t) { "Failed to warm DomainDatabase" }
+                }
+            }
+        }
+    }
 
     private fun initSentry() {
         if (SENTRY_DSN.isEmpty()) return


### PR DESCRIPTION
Closes #123.

`DomainDatabase` is a Koin `single` whose factory calls `RoomDatabase.Builder.build()`. Resolution was lazy — the first DAO request happened during `HomeScreen`'s `koinViewModel()` call on the Main thread, which drove `build()` (and, after a schema bump, the `fallbackToDestructiveMigration(dropAllTables = true)` table drop/recreate) on the first frame. This change fires off `getKoin().get<DomainDatabase>()` on a `SupervisorJob() + Dispatchers.IO` scope immediately after `startKoin {}` returns, moving the build cost off-main before the first composition. Failures during warm-up are caught and logged via the project `Logger`, with `CancellationException` rethrown.

`:app` doesn't have `androidx.room` on its compile classpath, so the recommended `db.openHelper.writableDatabase` access isn't reachable here without expanding the module's dependencies (out of scope for a one-file additive fix). Resolving the singleton is sufficient to take the `.build()` cost off-main; the actual SQLite connection then opens lazily on the first DAO query, which already runs on a coroutine dispatcher.

## Test plan
- [ ] Cold-start the debug build on a device; confirm no `StrictMode` `DiskReadViolation` / `DiskWriteViolation` from `Room.databaseBuilder(...).build()` shows up under the Main thread (verification mechanism per the issue body — no JVM unit test added since the fix is "do existing work earlier on a different thread").
- [ ] Bump `DomainDatabase` `@Database(version = N)` locally to force destructive migration on next install; verify the migration no longer fires from the Main thread on first composition.

🤖 Generated with [Claude Code](https://claude.com/claude-code)