### PR TITLE
fix: batch six low-severity bug-hunt findings (#125-#130)

### DIFF
--- a/common/src/androidMain/kotlin/pm/bam/gamedeals/common/storage/SharedPreferencesBackend.kt
+++ b/common/src/androidMain/kotlin/pm/bam/gamedeals/common/storage/SharedPreferencesBackend.kt
@@ -1,6 +1,7 @@
 package pm.bam.gamedeals.common.storage
 
 import android.content.SharedPreferences
+import androidx.annotation.WorkerThread
 
 internal class SharedPreferencesBackend(
     private val prefs: SharedPreferences,
@@ -10,10 +11,12 @@ internal class SharedPreferencesBackend(
 
     // commit() rather than apply(): callers run this off-thread inside withContext(IO) and
     // expect a truthful Boolean reflecting whether the write actually succeeded.
+    @WorkerThread
     override fun writeString(key: String, value: String): Boolean =
         prefs.edit().putString(key, value).commit()
 
     override fun contains(key: String): Boolean = prefs.contains(key)
 
+    @WorkerThread
     override fun remove(key: String): Boolean = prefs.edit().remove(key).commit()
 }

--- a/common/src/iosMain/kotlin/pm/bam/gamedeals/common/datetime/formatting/PlatformDateFormatter.ios.kt
+++ b/common/src/iosMain/kotlin/pm/bam/gamedeals/common/datetime/formatting/PlatformDateFormatter.ios.kt
@@ -10,11 +10,11 @@ import platform.Foundation.NSTimeZone
 import platform.Foundation.currentLocale
 import platform.Foundation.systemTimeZone
 
-private val iosFormatter = NSDateFormatter().apply {
-    dateFormat = "MMM dd, yyyy"
-    locale = NSLocale.currentLocale
-    timeZone = NSTimeZone.systemTimeZone
+internal actual fun formatLocaleAwareDate(instant: Instant): String {
+    val formatter = NSDateFormatter().apply {
+        dateFormat = "MMM dd, yyyy"
+        locale = NSLocale.currentLocale
+        timeZone = NSTimeZone.systemTimeZone
+    }
+    return formatter.stringFromDate(instant.toNSDate())
 }
-
-internal actual fun formatLocaleAwareDate(instant: Instant): String =
-    iosFormatter.stringFromDate(instant.toNSDate())

--- a/feature/game/src/commonMain/kotlin/pm/bam/gamedeals/feature/game/ui/GameScreen.kt
+++ b/feature/game/src/commonMain/kotlin/pm/bam/gamedeals/feature/game/ui/GameScreen.kt
@@ -298,7 +298,9 @@ private fun ScreenScaffold(
     onRetry: () -> Unit
 ) {
     val snackbarHostState = remember { SnackbarHostState() }
-    val scrollBehavior = TopAppBarDefaults.pinnedScrollBehavior(rememberTopAppBarState())
+    val topAppBarState = rememberTopAppBarState()
+    val canScroll = remember { { true } }
+    val scrollBehavior = TopAppBarDefaults.pinnedScrollBehavior(topAppBarState, canScroll)
     val currentOnRetry by rememberUpdatedState(onRetry)
 
     val errorMessage = stringResource(Res.string.game_screen_data_loading_error_msg)

--- a/feature/game/src/commonMain/kotlin/pm/bam/gamedeals/feature/game/ui/GameScreen.kt
+++ b/feature/game/src/commonMain/kotlin/pm/bam/gamedeals/feature/game/ui/GameScreen.kt
@@ -71,6 +71,7 @@ import pm.bam.gamedeals.common.ui.generated.resources.Res as CommonRes
 import pm.bam.gamedeals.common.ui.generated.resources.store
 import pm.bam.gamedeals.common.ui.generated.resources.videogame_thumb
 
+private val AlwaysScrollable: () -> Boolean = { true }
 
 @Composable
 internal fun GameScreen(
@@ -299,8 +300,7 @@ private fun ScreenScaffold(
 ) {
     val snackbarHostState = remember { SnackbarHostState() }
     val topAppBarState = rememberTopAppBarState()
-    val canScroll = remember { { true } }
-    val scrollBehavior = TopAppBarDefaults.pinnedScrollBehavior(topAppBarState, canScroll)
+    val scrollBehavior = TopAppBarDefaults.pinnedScrollBehavior(topAppBarState, AlwaysScrollable)
     val currentOnRetry by rememberUpdatedState(onRetry)
 
     val errorMessage = stringResource(Res.string.game_screen_data_loading_error_msg)

--- a/feature/search/src/commonMain/kotlin/pm/bam/gamedeals/feature/search/ui/SearchScreen.kt
+++ b/feature/search/src/commonMain/kotlin/pm/bam/gamedeals/feature/search/ui/SearchScreen.kt
@@ -349,9 +349,9 @@ private fun Filters(
     val steamRange = SearchFilterMinRate..SearchFilterMaxRate
     val existingMin = existingSearchParameters.steamMinRating?.toFloat() ?: SearchFilterMinRate
 
-    var priceSliderValue by rememberSaveable(stateSaver = floatRangeSaver) { mutableStateOf(existingPriceRange) }
-    var steamSliderValue by rememberSaveable { mutableFloatStateOf(existingMin) }
-    var exactMatch by rememberSaveable { mutableStateOf(existingSearchParameters.exact ?: false) }
+    var priceSliderValue by rememberSaveable(existingPriceRange, stateSaver = floatRangeSaver) { mutableStateOf(existingPriceRange) }
+    var steamSliderValue by rememberSaveable(existingMin) { mutableFloatStateOf(existingMin) }
+    var exactMatch by rememberSaveable(existingSearchParameters.exact) { mutableStateOf(existingSearchParameters.exact ?: false) }
 
     Column(
         modifier = Modifier

--- a/feature/search/src/commonMain/kotlin/pm/bam/gamedeals/feature/search/ui/SearchViewModel.kt
+++ b/feature/search/src/commonMain/kotlin/pm/bam/gamedeals/feature/search/ui/SearchViewModel.kt
@@ -6,8 +6,6 @@ import androidx.lifecycle.viewModelScope
 import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.toImmutableList
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.channels.BufferOverflow
-import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -16,6 +14,7 @@ import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.onEach
+import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import kotlinx.serialization.ExperimentalSerializationApi
 import pm.bam.gamedeals.common.flatMapLatestDelayAtLeast
@@ -32,11 +31,10 @@ internal class SearchViewModel(
     private val gamesRepository: GamesRepository
 ) : ViewModel() {
 
-    // We store and react to the Query changes so that only a single search flow can exists
-    private val searchParametersFlow = MutableSharedFlow<SearchParameters?>(
-        replay = 1,
-        onBufferOverflow = BufferOverflow.DROP_OLDEST
-    )
+    // We store and react to the Query changes so that only a single search flow can exists.
+    // StateFlow gives us atomic read-modify-write via update {} (L-2026-05-02-01) and
+    // conflated replay-of-latest semantics, replacing the prior SharedFlow + replayCache RMW.
+    private val searchParametersFlow = MutableStateFlow(SearchParameters())
 
     private val _resultState = MutableStateFlow<SearchData>(SearchData.Empty)
     val resultState: StateFlow<SearchData> = _resultState.asStateFlow()
@@ -45,7 +43,7 @@ internal class SearchViewModel(
         viewModelScope.launch {
             searchParametersFlow
                 .flatMapLatest { dealsSearch ->
-                    when (dealsSearch == null || (dealsSearch.title == null && dealsSearch.lowerPrice == null && dealsSearch.upperPrice == null && dealsSearch.steamMinRating == null)) {
+                    when (dealsSearch.title == null && dealsSearch.lowerPrice == null && dealsSearch.upperPrice == null && dealsSearch.steamMinRating == null) {
                         true -> flowOf(SearchData.Empty)
                         else -> flowOf(dealsSearch)
                             .onEach { _resultState.emit(SearchData.Loading) }
@@ -71,16 +69,14 @@ internal class SearchViewModel(
         steamMinimum: Int? = null,
         exactMatch: Boolean? = null
     ) {
-        viewModelScope.launch {
-            val current = searchParametersFlow.replayCache.firstOrNull() ?: SearchParameters()
-            val searchParameters = SearchParameters(
+        searchParametersFlow.update { current ->
+            SearchParameters(
                 title = title ?: current.title,
                 lowerPrice = lowerPrice ?: current.lowerPrice,
                 upperPrice = upperPrice ?: current.upperPrice,
                 steamMinRating = steamMinimum ?: current.steamMinRating,
                 exact = exactMatch ?: current.exact
             )
-            searchParametersFlow.emit(searchParameters)
         }
     }
 

--- a/feature/store/src/commonMain/kotlin/pm/bam/gamedeals/feature/store/ui/StoreScreen.kt
+++ b/feature/store/src/commonMain/kotlin/pm/bam/gamedeals/feature/store/ui/StoreScreen.kt
@@ -216,7 +216,10 @@ private fun StoreToolbar(
     onBack: () -> Unit,
     storeDetails: Store? = null
 ) {
-    val scrollBehavior: TopAppBarScrollBehavior = TopAppBarDefaults.pinnedScrollBehavior(rememberTopAppBarState())
+    val topAppBarState = rememberTopAppBarState()
+    val canScroll = remember { { true } }
+    val scrollBehavior: TopAppBarScrollBehavior =
+        TopAppBarDefaults.pinnedScrollBehavior(topAppBarState, canScroll)
 
     TopAppBar(
         colors = TopAppBarDefaults.topAppBarColors(

--- a/feature/store/src/commonMain/kotlin/pm/bam/gamedeals/feature/store/ui/StoreScreen.kt
+++ b/feature/store/src/commonMain/kotlin/pm/bam/gamedeals/feature/store/ui/StoreScreen.kt
@@ -66,6 +66,8 @@ import pm.bam.gamedeals.feature.store.generated.resources.store_screen_navigatio
 import pm.bam.gamedeals.feature.store.generated.resources.store_screen_store_banner
 import pm.bam.gamedeals.feature.store.ui.StoreViewModel.StoreScreenData
 
+private val AlwaysScrollable: () -> Boolean = { true }
+
 @Composable
 internal fun StoreScreen(
     onBack: () -> Unit,
@@ -217,9 +219,8 @@ private fun StoreToolbar(
     storeDetails: Store? = null
 ) {
     val topAppBarState = rememberTopAppBarState()
-    val canScroll = remember { { true } }
     val scrollBehavior: TopAppBarScrollBehavior =
-        TopAppBarDefaults.pinnedScrollBehavior(topAppBarState, canScroll)
+        TopAppBarDefaults.pinnedScrollBehavior(topAppBarState, AlwaysScrollable)
 
     TopAppBar(
         colors = TopAppBarDefaults.topAppBarColors(

--- a/logging/src/commonMain/kotlin/pm/bam/gamedeals/logging/Logger.kt
+++ b/logging/src/commonMain/kotlin/pm/bam/gamedeals/logging/Logger.kt
@@ -27,6 +27,12 @@ interface Logger {
      * Add the provided [loggingInterface] to the [Set] of loggers that will receive log events.
      *
      * No exception will be thrown if the provided [loggingInterface] is already found in the existing set.
+     *
+     * **Thread-safety:** Listener registration is **not** thread-safe. Callers must register and
+     * unregister listeners during DI bootstrap, *before* any consumer calls [log] or
+     * [fatalThrowable]. Concurrent registration with active logging is a race against the
+     * underlying [MutableSet]. If a future requirement needs runtime registration, swap the
+     * backing set for a thread-safe (e.g. copy-on-write) variant first.
      */
     fun addLoggerListener(loggingInterface: LoggingInterface)
 
@@ -34,6 +40,8 @@ interface Logger {
      * Remove the provided [loggingInterface] from the [Set] of loggers that will receive log events.
      *
      * No exception will be thrown if the provided [loggingInterface] is not found in the existing set.
+     *
+     * **Thread-safety:** See [addLoggerListener]; the same DI-bootstrap-only contract applies.
      */
     fun removeLoggerListener(loggingInterface: LoggingInterface)
 }

--- a/logging/src/commonMain/kotlin/pm/bam/gamedeals/logging/LoggerImpl.kt
+++ b/logging/src/commonMain/kotlin/pm/bam/gamedeals/logging/LoggerImpl.kt
@@ -1,5 +1,18 @@
 package pm.bam.gamedeals.logging
 
+/**
+ * Default [Logger] implementation backed by a plain [MutableSet] of [LoggingInterface]s.
+ *
+ * **Thread-safety contract:** the listener set is not synchronized. The expected lifecycle is:
+ * 1. The set is populated during DI bootstrap (via constructor injection plus optional
+ *    [addLoggerListener] calls in the DI module setup).
+ * 2. Once log consumers start calling [log] / [fatalThrowable], the set is treated as read-only.
+ *
+ * Concurrent [addLoggerListener] / [removeLoggerListener] calls racing with active [log] /
+ * [fatalThrowable] calls would be a race against the underlying [MutableSet]; if such a use
+ * case ever lands, swap [loggers] for a thread-safe (e.g. copy-on-write) variant first rather
+ * than relying on incidental synchronization.
+ */
 internal class LoggerImpl(private val loggers: MutableSet<LoggingInterface>) : Logger {
 
     /**


### PR DESCRIPTION
Closes #125.
Closes #126.
Closes #127.
Closes #128.
Closes #129.
Closes #130.

Batch resolution of the six remaining low-severity findings from the
2026-05-06 bug hunt. One commit per issue so the change history is
bisectable; all six commits compile independently.

## Commits
- `fix(#128): annotate KeyValueBackend.writeString as @WorkerThread` — Lint will now flag Main-thread callers. Annotation on the Android impl rather than commonMain since `androidx.annotation` isn't on the `:common` commonMain classpath today; the Main-thread hazard is Android-only anyway.
- `fix(#125): memoize TopAppBar pinnedScrollBehavior` — `pinnedScrollBehavior` is itself `@Composable` and internally `remember(state, canScroll)`s, but the default `canScroll = { true }` is a fresh lambda per recomposition so the inner `remember` key compares unequal each pass. Fix is to hoist `canScroll` into a stable remembered lambda; this stabilises the inner `remember` and is the actual equivalent of the issue body's suggested wrap (which doesn't compile because the inner call is `@Composable`).
- `fix(#126): construct NSDateFormatter per-call to avoid shared mutable state` — eliminates the foot-gun if someone later adds a mutator. NSDateFormatter is cheap to construct on iOS for formatting use.
- `fix(#129): switch searchParametersFlow to MutableStateFlow with atomic update` — uses `.update {}` per L-2026-05-02-01; replaces the latent read-modify-write race against `replayCache.firstOrNull()`. `searchGames` no longer needs `viewModelScope.launch` since `update` is non-suspending. Existing `SearchViewModelTest` passes unchanged.
- `fix(#127): document LoggerImpl listener-registration contract in KDoc` — option 2 from the issue body. atomicfu copy-on-write (option 1) deferred as over-investment for a Low/Low-confidence latent issue with no current race; atomicfu isn't currently in `libs.versions.toml`, and adding a new build dep for documentation-only intent isn't warranted.
- `fix(#130): re-key Filters rememberSaveable on existingSearchParameters` — changes UX from "sheet slots persist across show/hide" to "slots reset when parent params change". No visible diff today since the parent doesn't update params while the sheet is closed; reviewer can push back if the persistent UX is preferred.

## Reviewer notes
- Five of the six are minor / latent; #129 is the closest to a real bug (RMW race) but unreachable from today's single call site. None are user-visible regressions today.
- #129 has a behavioural side-effect: StateFlow conflates equal-by-value emissions, so re-tapping search with identical parameters no longer restarts the search flow. Today's only call site triggers on real param changes, so this is a net positive; if later UX requires re-tap to always re-fire, switch to a separate trigger Flow rather than back to SharedFlow + replayCache RMW.
- #125 deviates from the issue body's literal suggestion because `pinnedScrollBehavior` is `@Composable` and can't be invoked from a non-composable `remember { }` lambda. The applied fix achieves the same goal (stable internal `remember` key) via a stable `canScroll` lambda.
- #127 and #130 are judgment calls — reasoning explained in their commit messages.
- All six mirror existing project lessons (L-2026-05-02-01 for #129) where applicable.

## Build verification
- `./gradlew :common:compileDebugKotlinAndroid :common:compileKotlinIosSimulatorArm64` — BUILD SUCCESSFUL
- `./gradlew :logging:compileDebugKotlinAndroid` — BUILD SUCCESSFUL
- `./gradlew :feature:game:compileDebugKotlinAndroid :feature:store:compileDebugKotlinAndroid` — BUILD SUCCESSFUL
- `./gradlew :feature:search:compileDebugKotlinAndroid :feature:search:testDebugUnitTest` — BUILD SUCCESSFUL

🤖 Generated with [Claude Code](https://claude.com/claude-code)