### PR TITLE
fix(common): read Locale and ZoneId per call in Android date formatter

### DIFF
--- a/common/src/androidMain/kotlin/pm/bam/gamedeals/common/datetime/formatting/PlatformDateFormatter.android.kt
+++ b/common/src/androidMain/kotlin/pm/bam/gamedeals/common/datetime/formatting/PlatformDateFormatter.android.kt
@@ -5,12 +5,13 @@ package pm.bam.gamedeals.common.datetime.formatting
 import kotlin.time.Instant
 import kotlin.time.toJavaInstant
 import java.time.ZoneId
+import java.time.format.DateTimeFormatter
 import java.util.Locale
 
-private val androidFormatter = java.time.format.DateTimeFormatter
-    .ofPattern("MMM dd, yyyy")
-    .withLocale(Locale.getDefault())
-    .withZone(ZoneId.systemDefault())
-
-internal actual fun formatLocaleAwareDate(instant: Instant): String =
-    androidFormatter.format(instant.toJavaInstant())
+internal actual fun formatLocaleAwareDate(instant: Instant): String {
+    val formatter = DateTimeFormatter
+        .ofPattern("MMM dd, yyyy")
+        .withLocale(Locale.getDefault())
+        .withZone(ZoneId.systemDefault())
+    return formatter.format(instant.toJavaInstant())
+}

--- a/common/src/androidUnitTest/kotlin/pm/bam/gamedeals/common/datetime/formatting/DateTimeFormatterImplTest.kt
+++ b/common/src/androidUnitTest/kotlin/pm/bam/gamedeals/common/datetime/formatting/DateTimeFormatterImplTest.kt
@@ -6,6 +6,7 @@ import io.mockk.every
 import io.mockk.mockk
 import kotlin.time.Instant
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotEquals
 import org.junit.Assert.assertNull
 import org.junit.Before
 import org.junit.Test
@@ -52,5 +53,22 @@ class DateTimeFormatterImplTest {
         val result = dateTimeFormatter.formatToISODateNullable(seconds)
 
         assertEquals("Jan 01, 2026", result)
+    }
+
+    @Test
+    fun `formatLocaleAwareDate reads Locale per call`() {
+        val instant = Instant.fromEpochSeconds(1767225600L) // 2026-01-01 00:00:00 UTC
+
+        Locale.setDefault(Locale.US)
+        val englishOutput = formatLocaleAwareDate(instant)
+
+        Locale.setDefault(Locale.FRENCH)
+        val frenchOutput = formatLocaleAwareDate(instant)
+
+        // The Android actual must read Locale.getDefault() on every invocation (matching iOS),
+        // not cache it at class-load time. Different default locales must yield different
+        // month-name renderings.
+        assertEquals("Jan 01, 2026", englishOutput)
+        assertNotEquals(englishOutput, frenchOutput)
     }
 }


### PR DESCRIPTION
Closes #143.

## Summary
The Android actual of `formatLocaleAwareDate` built a `java.time.DateTimeFormatter` once at class load, capturing `Locale.getDefault()` and `ZoneId.systemDefault()` for the lifetime of the process. The iOS actual constructs an `NSDateFormatter` per call and reads `NSLocale.currentLocale` / `NSTimeZone.systemTimeZone` each time, so the two platforms drifted whenever the user changed locale or timezone in Settings (wrong-language month names, dates off by hours/days after a TZ change).

This change moves the formatter construction inside `formatLocaleAwareDate` on Android so the system locale and zone are observed on every invocation, matching iOS.

## Changes
- `common/src/androidMain/kotlin/pm/bam/gamedeals/common/datetime/formatting/PlatformDateFormatter.android.kt`: build `DateTimeFormatter` per call.
- `common/src/androidUnitTest/.../DateTimeFormatterImplTest.kt`: added one test (`formatLocaleAwareDate reads Locale per call`) that flips `Locale.setDefault` between two calls and asserts the output differs — fits the existing JUnit/MockK pattern in the file.

## Test plan
- [x] `./gradlew :common:compileDebugKotlinAndroid` passes.
- [x] `./gradlew :common:testDebugUnitTest` passes (4/4 tests in `DateTimeFormatterImplTest`, including the new per-call locale read test).

🤖 Generated with [Claude Code](https://claude.com/claude-code)