### PR TITLE
fix(ios): resolve key window via connectedScenes and anchor share popover for iPad

### DIFF
--- a/common/ui/src/iosMain/kotlin/pm/bam/gamedeals/common/ui/platform/PlatformActions.ios.kt
+++ b/common/ui/src/iosMain/kotlin/pm/bam/gamedeals/common/ui/platform/PlatformActions.ios.kt
@@ -1,19 +1,73 @@
+@file:OptIn(kotlinx.cinterop.ExperimentalForeignApi::class)
+
 package pm.bam.gamedeals.common.ui.platform
 
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
+import kotlinx.cinterop.useContents
+import platform.CoreGraphics.CGRectMake
 import platform.UIKit.UIActivityViewController
 import platform.UIKit.UIApplication
+import platform.UIKit.UISceneActivationStateForegroundActive
+import platform.UIKit.UIWindow
+import platform.UIKit.UIWindowScene
+import platform.UIKit.popoverPresentationController
 
 class IosPlatformActions : PlatformActions {
     override fun share(text: String) {
+        val keyWindow = resolveKeyWindow() ?: return
+        val rootViewController = keyWindow.rootViewController ?: return
+
         val vc = UIActivityViewController(
             activityItems = listOf(text),
             applicationActivities = null,
         )
-        UIApplication.sharedApplication.keyWindow
-            ?.rootViewController
-            ?.presentViewController(vc, animated = true, completion = null)
+
+        // iPad requires a popover anchor; without it UIKit throws NSInvalidArgumentException.
+        // Anchor a small rect near the center of the resolved key window so the popover is
+        // centered regardless of where the user tapped.
+        vc.popoverPresentationController?.let { popover ->
+            popover.sourceView = keyWindow
+            keyWindow.bounds.useContents {
+                popover.sourceRect = CGRectMake(
+                    x = size.width / 2.0 - 1.0,
+                    y = size.height / 2.0 - 1.0,
+                    width = 2.0,
+                    height = 2.0,
+                )
+            }
+        }
+
+        rootViewController.presentViewController(vc, animated = true, completion = null)
+    }
+
+    /**
+     * Resolves the app's current key window via `connectedScenes`. `UIApplication.keyWindow`
+     * is deprecated since iOS 13 and returns nil for multi-scene apps. Prefers a foreground-active
+     * scene's `keyWindow`, falling back to that scene's first window, then to any scene's window.
+     */
+    private fun resolveKeyWindow(): UIWindow? {
+        val scenes = UIApplication.sharedApplication.connectedScenes
+        var fallbackKeyWindow: UIWindow? = null
+        var fallbackFirstWindow: UIWindow? = null
+
+        for (scene in scenes) {
+            val windowScene = scene as? UIWindowScene ?: continue
+            val windows = windowScene.windows.filterIsInstance<UIWindow>()
+            val sceneKeyWindow = windowScene.keyWindow ?: windows.firstOrNull()
+
+            if (windowScene.activationState == UISceneActivationStateForegroundActive) {
+                if (sceneKeyWindow != null) return sceneKeyWindow
+            } else {
+                if (fallbackKeyWindow == null && windowScene.keyWindow != null) {
+                    fallbackKeyWindow = windowScene.keyWindow
+                }
+                if (fallbackFirstWindow == null && windows.isNotEmpty()) {
+                    fallbackFirstWindow = windows.first()
+                }
+            }
+        }
+        return fallbackKeyWindow ?: fallbackFirstWindow
     }
 }
 


### PR DESCRIPTION
Closes #144.

## Summary

`IosPlatformActions.share` had two compounding UIKit issues:

1. `UIApplication.sharedApplication.keyWindow` has been deprecated since iOS 13 and returns `nil` for multi-scene apps, so the share sheet silently never appeared on modern iPhones.
2. `UIActivityViewController` presented on iPad requires its `popoverPresentationController` to be configured with `sourceView`/`sourceRect` (or `barButtonItem`). Without it, UIKit raises `NSInvalidArgumentException` and crashes the app the first time a user taps share.

## Fix

- Resolve the key window by iterating `UIApplication.connectedScenes`, preferring a `UIWindowScene` whose `activationState == UISceneActivationStateForegroundActive` and taking its `keyWindow` (falling back to that scene's first window, then to any other scene's window).
- Anchor the popover at a 2-point rect near the center of the resolved key window via `popoverPresentationController.sourceView`/`sourceRect` before presenting.
- If no key window can be resolved, return silently rather than calling into a `nil` root view controller (the share will no-op for that frame; no logger is available in `:common:ui` iosMain).

The `expect`/`actual` signature of `PlatformActions.share(text: String)` is unchanged; Android side untouched.

## Files changed

- `common/ui/src/iosMain/kotlin/pm/bam/gamedeals/common/ui/platform/PlatformActions.ios.kt`

## Test plan

- [x] `./gradlew :common:ui:compileKotlinIosSimulatorArm64` — passes
- [x] `./gradlew :common:ui:compileKotlinIosArm64` — passes
- [x] `./gradlew :common:ui:compileDebugKotlinAndroid` — passes (sanity check, expect/actual unchanged)
- [ ] Manual: tap Share on an iPad simulator — popover appears centered, no crash
- [ ] Manual: tap Share on an iPhone simulator — share sheet presents from the bottom as before

No automated tests added — the module has no `iosTest` source set and the change is a thin UIKit-API correctness fix that would require a simulator-hosted integration test to exercise meaningfully.

🤖 Generated with [Claude Code](https://claude.com/claude-code)