### PR TITLE
fix(domain): pin Room query dispatcher via setQueryCoroutineContext

### DIFF
--- a/domain/src/androidMain/kotlin/pm/bam/gamedeals/domain/di/DomainAndroidModule.kt
+++ b/domain/src/androidMain/kotlin/pm/bam/gamedeals/domain/di/DomainAndroidModule.kt
@@ -2,6 +2,7 @@ package pm.bam.gamedeals.domain.di
 
 import androidx.room.Room
 import androidx.room.RoomDatabase
+import kotlinx.coroutines.Dispatchers
 import org.koin.android.ext.koin.androidContext
 import org.koin.dsl.module
 import pm.bam.gamedeals.domain.db.DomainDatabase
@@ -20,5 +21,6 @@ val domainAndroidModule = module {
                 { sqlQuery, bindArgs -> verbose(logger) { "SQL Query: $sqlQuery SQL Args: $bindArgs" } },
                 Executors.newSingleThreadExecutor()
             )
+            .setQueryCoroutineContext(Dispatchers.IO)
     }
 }

--- a/domain/src/iosMain/kotlin/pm/bam/gamedeals/domain/di/DomainIosModule.kt
+++ b/domain/src/iosMain/kotlin/pm/bam/gamedeals/domain/di/DomainIosModule.kt
@@ -3,6 +3,7 @@ package pm.bam.gamedeals.domain.di
 import androidx.room.Room
 import androidx.room.RoomDatabase
 import androidx.sqlite.driver.bundled.BundledSQLiteDriver
+import kotlinx.coroutines.Dispatchers
 import org.koin.dsl.module
 import platform.Foundation.NSDocumentDirectory
 import platform.Foundation.NSSearchPathForDirectoriesInDomains
@@ -16,6 +17,8 @@ val domainIosModule = module {
         ).first() as String
         Room.databaseBuilder<DomainDatabase>(
             name = "$documents/DomainDatabase.db"
-        ).setDriver(BundledSQLiteDriver())
+        )
+            .setDriver(BundledSQLiteDriver())
+            .setQueryCoroutineContext(Dispatchers.Default)
     }
 }


### PR DESCRIPTION
Closes #146.

## Summary
- Add `.setQueryCoroutineContext(...)` to the `Room.databaseBuilder<DomainDatabase>(...)` chain in `DomainAndroidModule.kt` and `DomainIosModule.kt`.
- Android pins queries to `Dispatchers.IO`. iOS pins queries to `Dispatchers.Default` (Kotlin/Native's `Dispatchers.IO` is internal and aliases to `Default` anyway — see `.claude/lessons.md` `L-2026-05-06-03`).
- Without an explicit query coroutine context, suspending DAO calls run on whatever context the caller is on, including `Dispatchers.Main` on iOS. The bundled SQLite driver work is synchronous under the hood, so this is a real jank/beachball risk. The Android builder's `Executors.newSingleThreadExecutor()` is wired into `setQueryCallback` — that's only the query-callback (logging) executor, not the query executor.

## Reviewer notes
- The issue body suggested `Dispatchers.IO` literal on iOS, but `Dispatchers.IO` is `internal` in `kotlinx.coroutines.Dispatchers` on Kotlin/Native (matches lesson `L-2026-05-06-03`). Compile confirmed: `Cannot access 'val IO: CoroutineDispatcher': it is internal`. Switched iOS to `Dispatchers.Default`, which is the same runtime dispatcher anyway and matches the existing pattern in `common/src/iosMain/.../CommonIosModule.kt`.
- No injected `ioDispatcher` exists in the `:common` Koin modules — `Dispatchers.IO` / `Dispatchers.Default` are referenced directly in platform-specific source sets — so I followed the same convention here rather than introducing a new DI bind.

## Test plan
- [x] `./gradlew :domain:compileDebugKotlinAndroid` — passes.
- [x] `./gradlew :domain:compileKotlinIosSimulatorArm64` — passes.
- [x] `./gradlew :domain:testDebugUnitTest` — passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)