### PR TITLE
refactor(app): hoist application-scoped CoroutineScope for cold-start work

### DIFF
--- a/app/src/main/java/pm/bam/gamedeals/GameDealsApplication.kt
+++ b/app/src/main/java/pm/bam/gamedeals/GameDealsApplication.kt
@@ -42,6 +42,17 @@ class GameDealsApplication : Application(), SingletonImageLoader.Factory {
 
     private val imageLoader: ImageLoader by inject()
 
+    /**
+     * Application-scoped fire-and-forget work, intended to be reused by future
+     * cold-start initializers (e.g. moving `Sentry.init` off the Main thread).
+     *
+     * Backed by a [SupervisorJob] so one failed child doesn't tear down siblings,
+     * and pinned to [Dispatchers.IO] since the typical use case is I/O-bound
+     * warm-up. Not cancelled manually — the [Application] lives for the entire
+     * process lifetime, so the scope dies with the process.
+     */
+    private val applicationScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+
     override fun onCreate() {
         super.onCreate()
         initSentry()
@@ -102,8 +113,7 @@ class GameDealsApplication : Application(), SingletonImageLoader.Factory {
      * structured concurrency stays honest if the scope is ever cancelled.
      */
     private fun warmDomainDatabase() {
-        val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
-        scope.launch {
+        applicationScope.launch {
             try {
                 get<DomainDatabase>()
             } catch (ce: CancellationException) {


### PR DESCRIPTION
Closes #153.

## Summary

`GameDealsApplication.warmDomainDatabase()` previously constructed a fresh `CoroutineScope(SupervisorJob() + Dispatchers.IO)` locally and immediately `launch`ed into it, dropping the handle. That works for a one-shot warm-up but leaves no way to share the scope across other cold-start initializers.

This PR hoists the scope to a `private val applicationScope` on `GameDealsApplication` and reuses it from `warmDomainDatabase()`. The `CancellationException` rethrow behaviour and the structured-concurrency-friendly error path are preserved verbatim.

The hoisted scope is intentionally left for #151 (Sentry.init off Main) to reuse when that lands in wave 2 — no manual cancellation, since the Application instance lives for the entire process lifetime.

## Validation

- `./gradlew :app:compileDebugKotlin` — BUILD SUCCESSFUL.
- `:app` has no `src/test` source set, so no unit tests to run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)