### PR TITLE
fix(domain): atomic toggleFavourite via DAO @Transaction

### DIFF
--- a/domain/src/commonMain/kotlin/pm/bam/gamedeals/domain/db/dao/FavouritesDao.kt
+++ b/domain/src/commonMain/kotlin/pm/bam/gamedeals/domain/db/dao/FavouritesDao.kt
@@ -4,6 +4,7 @@ import androidx.room.Dao
 import androidx.room.Insert
 import androidx.room.OnConflictStrategy
 import androidx.room.Query
+import androidx.room.Transaction
 import kotlinx.coroutines.flow.Flow
 import pm.bam.gamedeals.domain.models.FavouriteGame
 
@@ -22,10 +23,37 @@ internal interface FavouritesDao {
     @Query("SELECT EXISTS(SELECT 1 FROM FavouriteGame WHERE gameID = :gameId)")
     fun observeIsFavourite(gameId: Int): Flow<Boolean>
 
+    /** Synchronous one-shot read used inside [toggleFavourite] for atomic read-modify-write. */
+    @Query("SELECT EXISTS(SELECT 1 FROM FavouriteGame WHERE gameID = :gameId)")
+    suspend fun isFavouriteNow(gameId: Int): Boolean
+
     /** REPLACE so re-favouriting refreshes [FavouriteGame.dateAddedMs]. */
     @Insert(onConflict = OnConflictStrategy.REPLACE)
     suspend fun addFavourites(vararg favourites: FavouriteGame)
 
     @Query("DELETE FROM FavouriteGame WHERE gameID = :gameId")
     suspend fun removeFavouriteById(gameId: Int)
+
+    /**
+     * Atomic toggle: reads current favourite state and inserts/deletes within a single
+     * transaction so concurrent callers can't both observe "not favourite" and double-insert
+     * (or both observe "favourite" and have one of the deletes lose). Returns the new state.
+     */
+    @Transaction
+    suspend fun toggleFavourite(gameId: Int, title: String, thumb: String, dateAddedMs: Long): Boolean {
+        val nowFavourite = !isFavouriteNow(gameId)
+        if (nowFavourite) {
+            addFavourites(
+                FavouriteGame(
+                    gameID = gameId,
+                    title = title,
+                    thumb = thumb,
+                    dateAddedMs = dateAddedMs,
+                )
+            )
+        } else {
+            removeFavouriteById(gameId)
+        }
+        return nowFavourite
+    }
 }

--- a/domain/src/commonMain/kotlin/pm/bam/gamedeals/domain/repositories/favourites/FavouritesRepository.kt
+++ b/domain/src/commonMain/kotlin/pm/bam/gamedeals/domain/repositories/favourites/FavouritesRepository.kt
@@ -1,7 +1,6 @@
 package pm.bam.gamedeals.domain.repositories.favourites
 
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.map
 import pm.bam.gamedeals.common.time.Clock
 import pm.bam.gamedeals.domain.db.dao.FavouritesDao
@@ -45,9 +44,11 @@ internal class FavouritesRepositoryImpl(
         favouritesDao.removeFavouriteById(gameId)
     }
 
-    override suspend fun toggleFavourite(gameId: Int, title: String, thumb: String): Boolean {
-        val nowFavourite = !favouritesDao.observeIsFavourite(gameId).first()
-        if (nowFavourite) addFavourite(gameId, title, thumb) else removeFavourite(gameId)
-        return nowFavourite
-    }
+    override suspend fun toggleFavourite(gameId: Int, title: String, thumb: String): Boolean =
+        favouritesDao.toggleFavourite(
+            gameId = gameId,
+            title = title,
+            thumb = thumb,
+            dateAddedMs = clock.nowMillis(),
+        )
 }

--- a/domain/src/commonTest/kotlin/pm/bam/gamedeals/domain/repositories/favourites/FavouritesRepositoryTest.kt
+++ b/domain/src/commonTest/kotlin/pm/bam/gamedeals/domain/repositories/favourites/FavouritesRepositoryTest.kt
@@ -3,7 +3,7 @@ package pm.bam.gamedeals.domain.repositories.favourites
 import dev.mokkery.MockMode
 import dev.mokkery.answering.returns
 import dev.mokkery.every
-import dev.mokkery.matcher.any
+import dev.mokkery.everySuspend
 import dev.mokkery.mock
 import dev.mokkery.verifySuspend
 import dev.mokkery.verify.VerifyMode.Companion.exactly
@@ -43,27 +43,51 @@ class FavouritesRepositoryTest {
     }
 
     @Test
-    fun toggle_when_not_favourite_adds_and_returns_true() = runTest {
-        every { favouritesDao.observeIsFavourite(7) } returns flowOf(false)
+    fun toggle_delegates_to_dao_and_returns_new_state_true() = runTest {
+        everySuspend {
+            favouritesDao.toggleFavourite(
+                gameId = 7,
+                title = "Game 7",
+                thumb = "thumb7",
+                dateAddedMs = FIXED_NOW_MS,
+            )
+        } returns true
 
         val now = impl.toggleFavourite(gameId = 7, title = "Game 7", thumb = "thumb7")
         assertTrue(now)
 
         verifySuspend(exactly(1)) {
-            favouritesDao.addFavourites(
-                FavouriteGame(gameID = 7, title = "Game 7", thumb = "thumb7", dateAddedMs = FIXED_NOW_MS)
+            favouritesDao.toggleFavourite(
+                gameId = 7,
+                title = "Game 7",
+                thumb = "thumb7",
+                dateAddedMs = FIXED_NOW_MS,
             )
         }
     }
 
     @Test
-    fun toggle_when_favourite_removes_and_returns_false() = runTest {
-        every { favouritesDao.observeIsFavourite(7) } returns flowOf(true)
+    fun toggle_delegates_to_dao_and_returns_new_state_false() = runTest {
+        everySuspend {
+            favouritesDao.toggleFavourite(
+                gameId = 7,
+                title = "Game 7",
+                thumb = "thumb7",
+                dateAddedMs = FIXED_NOW_MS,
+            )
+        } returns false
 
         val now = impl.toggleFavourite(gameId = 7, title = "Game 7", thumb = "thumb7")
         assertFalse(now)
 
-        verifySuspend(exactly(1)) { favouritesDao.removeFavouriteById(7) }
+        verifySuspend(exactly(1)) {
+            favouritesDao.toggleFavourite(
+                gameId = 7,
+                title = "Game 7",
+                thumb = "thumb7",
+                dateAddedMs = FIXED_NOW_MS,
+            )
+        }
     }
 
     @Test


### PR DESCRIPTION
Closes #150.

## Summary
- `FavouritesRepository.toggleFavourite` previously did a non-atomic read-modify-write (`observeIsFavourite(gameId).first()` then `addFavourite`/`removeFavourite`), which is racy under concurrent toggles (TOCTOU — two callers can both read `false`, both insert; or both read `true` and one delete loses).
- Pushed the read-modify-write into a single `@Transaction suspend fun toggleFavourite(gameId, title, thumb, dateAddedMs): Boolean` default method on `FavouritesDao`, which calls a new synchronous `isFavouriteNow(gameId)` and then inserts (REPLACE — matches the existing `addFavourites` insert shape) or deletes accordingly inside one Room transaction. Returns the new boolean state.
- `FavouritesRepositoryImpl.toggleFavourite` now delegates straight to the DAO method, passing `clock.nowMillis()` as `dateAddedMs`. The public `FavouritesRepository` interface signature is unchanged, so `:feature:home`, `:feature:game`, and `:feature:store` call-sites compile without modification.
- `FavouritesRepositoryTest` toggle tests now stub the DAO's `toggleFavourite` directly with `everySuspend { ... } returns <Boolean>` (per L-2026-05-11-03 — `MockMode.autoUnit` can't auto-stub non-Unit suspend calls).

## Validation
- `./gradlew :domain:testDebugUnitTest` — BUILD SUCCESSFUL (KSP processed the new `@Transaction` default method cleanly via `:domain:kspDebugKotlinAndroid`).
- `./gradlew :domain:compileKotlinIosSimulatorArm64` — BUILD SUCCESSFUL (Room KSP also clean on `:domain:kspKotlinIosSimulatorArm64`).

## Test plan
- [x] `:domain:testDebugUnitTest` green
- [x] `:domain:compileKotlinIosSimulatorArm64` green (Room KSP accepts the default method on iOS too)
- [x] Repo public API unchanged — feature module call-sites unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)