### PR TITLE
refactor(giveaways): use WhileSubscribed(5_000) for uiState stateIn

### DIFF
--- a/feature/giveaways/src/commonMain/kotlin/pm/bam/gamedeals/feature/giveaways/ui/GiveawaysViewModel.kt
+++ b/feature/giveaways/src/commonMain/kotlin/pm/bam/gamedeals/feature/giveaways/ui/GiveawaysViewModel.kt
@@ -62,7 +62,7 @@ internal class GiveawaysViewModel(
         GiveawaysScreenData(status = status, giveaways = giveaways.toImmutableList())
     }
         .logFlow(logger)
-        .stateIn(viewModelScope, SharingStarted.Eagerly, GiveawaysScreenData())
+        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), GiveawaysScreenData())
 
     fun reloadGiveaways() {
         viewModelScope.launch {

--- a/feature/giveaways/src/commonTest/kotlin/pm/bam/gamedeals/feature/giveaways/ui/GiveawaysViewModelTest.kt
+++ b/feature/giveaways/src/commonTest/kotlin/pm/bam/gamedeals/feature/giveaways/ui/GiveawaysViewModelTest.kt
@@ -48,8 +48,7 @@ class GiveawaysViewModelTest : MainDispatcherTest() {
         val viewModel = GiveawaysViewModel(TestingLoggingListener(), giveawaysRepository)
 
         val emissions = observeStates(viewModel)
-        assertEquals(1, emissions.size)
-        assertEquals(GiveawaysViewModel.GiveawaysScreenStatus.SUCCESS, emissions.first().status)
+        assertEquals(GiveawaysViewModel.GiveawaysScreenStatus.SUCCESS, emissions.last().status)
     }
 
     @Test
@@ -58,21 +57,25 @@ class GiveawaysViewModelTest : MainDispatcherTest() {
         val viewModel = GiveawaysViewModel(TestingLoggingListener(), giveawaysRepository)
 
         val emissions = observeStates(viewModel)
-        assertEquals(1, emissions.size)
-        assertEquals(GiveawaysViewModel.GiveawaysScreenStatus.ERROR, emissions.first().status)
+        assertEquals(GiveawaysViewModel.GiveawaysScreenStatus.ERROR, emissions.last().status)
     }
 
     @Test
     fun reload_giveaways() = runTest {
         every { giveawaysRepository.observeGiveaways() } returns flowOf(emptyList())
+        val refreshGate = CompletableDeferred<Unit>()
+        everySuspend { giveawaysRepository.refreshGiveaways() } calls { refreshGate.await() }
+
         val viewModel = GiveawaysViewModel(TestingLoggingListener(), giveawaysRepository)
+
+        // Subscribe before triggering reload so LOADING is observable under
+        // SharingStarted.WhileSubscribed semantics.
+        val emissions = observeStates(viewModel)
         viewModel.reloadGiveaways()
 
-        val emissions = observeStates(viewModel)
-        assertEquals(1, emissions.size)
+        assertEquals(GiveawaysViewModel.GiveawaysScreenStatus.LOADING, emissions.last().status)
 
-        // Loading is emitted twice, but observed only once because StateFlow emits only distinct values
-        assertEquals(GiveawaysViewModel.GiveawaysScreenStatus.LOADING, emissions.first().status)
+        refreshGate.complete(Unit)
     }
 
     @Test
@@ -82,9 +85,12 @@ class GiveawaysViewModelTest : MainDispatcherTest() {
         everySuspend { giveawaysRepository.refreshGiveaways() } calls { refreshGate.await() }
 
         val viewModel = GiveawaysViewModel(TestingLoggingListener(), giveawaysRepository)
+
+        // Subscribe before triggering reload so LOADING is observable under
+        // SharingStarted.WhileSubscribed semantics.
+        val emissions = observeStates(viewModel)
         viewModel.reloadGiveaways()
 
-        val emissions = observeStates(viewModel)
         assertEquals(GiveawaysViewModel.GiveawaysScreenStatus.LOADING, emissions.last().status)
 
         refreshGate.complete(Unit)
@@ -108,11 +114,10 @@ class GiveawaysViewModelTest : MainDispatcherTest() {
         viewModel.loadGiveaway(para)
 
         val emissions = observeStates(viewModel)
-        assertEquals(1, emissions.size)
-        assertEquals(GiveawaysViewModel.GiveawaysScreenStatus.SUCCESS, emissions.first().status)
-        assertEquals(2, emissions.first().giveaways.size)
-        assertEquals(resultThree, emissions.first().giveaways.first())
-        assertEquals(resultOne, emissions.first().giveaways.second())
+        assertEquals(GiveawaysViewModel.GiveawaysScreenStatus.SUCCESS, emissions.last().status)
+        assertEquals(2, emissions.last().giveaways.size)
+        assertEquals(resultThree, emissions.last().giveaways.first())
+        assertEquals(resultOne, emissions.last().giveaways.second())
     }
 
     @Test


### PR DESCRIPTION
Closes #149.

## Summary
- Switch `GiveawaysViewModel.uiState`'s sharing strategy from `SharingStarted.Eagerly` to `SharingStarted.WhileSubscribed(5_000)`, matching the other 5 ViewModels in the codebase.
- Stops the Room `observeGiveaways()` flow from staying hot for the ViewModel's whole lifetime — the upstream now tears down 5s after the last subscriber disappears.

## Test changes
The existing tests were written against `Eagerly` semantics (upstream primed before the test subscriber attached). Under `WhileSubscribed` the subscriber sees the placeholder `GiveawaysScreenData()` before the upstream's first real emission, so:
- Assertions now use `emissions.last()` instead of `emissions.first()` / `emissions.size == 1`.
- `reload_giveaways` and `reload_giveaways_emits_LOADING_before_refresh_completes` subscribe **before** invoking `reloadGiveaways()` so the LOADING state is observable, and the refresh is gated so SUCCESS doesn't race in and overwrite it.

## Test plan
- [x] `./gradlew :feature:giveaways:testDebugUnitTest` — all 11 tests pass.
- [x] `./gradlew :feature:giveaways:compileKotlinIosSimulatorArm64` — passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)