### PR TITLE
fix(compose-stability): replace Pair<Store, …> with @Immutable wrappers

### DIFF
--- a/common/ui/src/androidInstrumentedTest/kotlin/pm/bam/gamedeals/common/ui/deal/DealBottomSheetTest.kt
+++ b/common/ui/src/androidInstrumentedTest/kotlin/pm/bam/gamedeals/common/ui/deal/DealBottomSheetTest.kt
@@ -181,7 +181,7 @@ class DealBottomSheetTest {
             dealId = dealId,
             gameSalesPriceDenominated = gamePrice,
             gameInfo = gameInfo,
-            cheaperStores = listOf(cheaperStore to cheaperStoreDetails),
+            cheaperStores = listOf(StoreCheaperStorePair(store = cheaperStore, cheaperStore = cheaperStoreDetails)),
             cheapestPrice = cheapestPrice,
         )
 

--- a/common/ui/src/commonMain/kotlin/pm/bam/gamedeals/common/ui/deal/DealBottomSheet.kt
+++ b/common/ui/src/commonMain/kotlin/pm/bam/gamedeals/common/ui/deal/DealBottomSheet.kt
@@ -230,16 +230,16 @@ private fun GameDetails(
                 data.cheaperStores.forEach {
                     val cheaperStoreRowCd = stringResource(
                         Res.string.deal_details_cheaper_store_row_description,
-                        it.first.storeName,
-                        it.second.salePriceDenominated,
+                        it.store.storeName,
+                        it.cheaperStore.salePriceDenominated,
                     )
                     Row(
                         modifier = Modifier
-                            .clickable(role = Role.Button) { goToWeb(cheapsharkDealRedirectUrl(it.second.dealID), data.gameName) }
+                            .clickable(role = Role.Button) { goToWeb(cheapsharkDealRedirectUrl(it.cheaperStore.dealID), data.gameName) }
                             .semantics { contentDescription = cheaperStoreRowCd },
                     ) {
                         AsyncImage(
-                            model = it.first.images.logo,
+                            model = it.store.images.logo,
                             contentDescription = stringResource(Res.string.deal_details_cheaper_store_thumbnail, data.store.storeName),
                             error = painterResource(Res.drawable.videogame_thumb),
                             contentScale = ContentScale.Fit,
@@ -252,7 +252,7 @@ private fun GameDetails(
                                 .fillMaxWidth()
                                 .align(Alignment.CenterVertically)
                                 .padding(horizontal = GameDealsCustomTheme.spacing.small),
-                            text = it.second.salePriceDenominated
+                            text = it.cheaperStore.salePriceDenominated
                         )
                     }
                 }
@@ -410,12 +410,18 @@ private fun DealContent_WithCheaperStores_Preview() {
             DealContent(
                 data = previewDealDetailsData.copy(
                     cheaperStores = listOf(
-                        PreviewStore.copy(storeID = 11, storeName = "Humble Store") to PreviewDealCheaperStore,
-                        PreviewStore.copy(storeID = 7, storeName = "GOG") to PreviewDealCheaperStore.copy(
-                            dealID = "cheaper-2",
-                            storeID = 7,
-                            salePriceValue = 5.99,
-                            salePriceDenominated = "$5.99",
+                        StoreCheaperStorePair(
+                            store = PreviewStore.copy(storeID = 11, storeName = "Humble Store"),
+                            cheaperStore = PreviewDealCheaperStore,
+                        ),
+                        StoreCheaperStorePair(
+                            store = PreviewStore.copy(storeID = 7, storeName = "GOG"),
+                            cheaperStore = PreviewDealCheaperStore.copy(
+                                dealID = "cheaper-2",
+                                storeID = 7,
+                                salePriceValue = 5.99,
+                                salePriceDenominated = "$5.99",
+                            ),
                         ),
                     ),
                     cheapestPrice = null,

--- a/common/ui/src/commonMain/kotlin/pm/bam/gamedeals/common/ui/deal/DealBottomSheetData.kt
+++ b/common/ui/src/commonMain/kotlin/pm/bam/gamedeals/common/ui/deal/DealBottomSheetData.kt
@@ -20,7 +20,7 @@ sealed class DealBottomSheetData(
         override val dealId: String,
         override val gameSalesPriceDenominated: String,
         val gameInfo: DealDetails.GameInfo,
-        val cheaperStores: List<Pair<Store, DealDetails.CheaperStore>>,
+        val cheaperStores: List<StoreCheaperStorePair>,
         val cheapestPrice: DealDetails.CheapestPrice?,
     ) : DealBottomSheetData(store, gameId, gameName, dealId, gameSalesPriceDenominated)
 

--- a/common/ui/src/commonMain/kotlin/pm/bam/gamedeals/common/ui/deal/DealDetailsController.kt
+++ b/common/ui/src/commonMain/kotlin/pm/bam/gamedeals/common/ui/deal/DealDetailsController.kt
@@ -56,7 +56,7 @@ class DealDetailsController(
                         gameSalesPriceDenominated = dealPriceDenominated,
                         gameInfo = dealDetails.gameInfo,
                         cheapestPrice = dealDetails.cheapestPrice,
-                        cheaperStores = dealDetails.cheaperStores.map { storesRepository.getStore(it.storeID) to it },
+                        cheaperStores = dealDetails.cheaperStores.map { StoreCheaperStorePair(store = storesRepository.getStore(it.storeID), cheaperStore = it) },
                     )
                 }
                 _dealDetails.emit(data)

--- a/common/ui/src/commonMain/kotlin/pm/bam/gamedeals/common/ui/deal/StoreCheaperStorePair.kt
+++ b/common/ui/src/commonMain/kotlin/pm/bam/gamedeals/common/ui/deal/StoreCheaperStorePair.kt
@@ -1,0 +1,18 @@
+package pm.bam.gamedeals.common.ui.deal
+
+import androidx.compose.runtime.Immutable
+import pm.bam.gamedeals.domain.models.DealDetails
+import pm.bam.gamedeals.domain.models.Store
+
+/**
+ * Compose-stable wrapper around a (Store, CheaperStore) tuple.
+ *
+ * Replaces `kotlin.Pair<Store, DealDetails.CheaperStore>` in composable
+ * parameter types so that wrapping list types are considered stable by the
+ * Compose compiler and skipping can apply.
+ */
+@Immutable
+data class StoreCheaperStorePair(
+    val store: Store,
+    val cheaperStore: DealDetails.CheaperStore,
+)

--- a/feature/game/src/androidInstrumentedTest/kotlin/pm/bam/gamedeals/feature/game/ui/GameScreenTest.kt
+++ b/feature/game/src/androidInstrumentedTest/kotlin/pm/bam/gamedeals/feature/game/ui/GameScreenTest.kt
@@ -148,7 +148,7 @@ class GameScreenTest {
         every { viewModel.uiState } returns MutableStateFlow(
             GameViewModel.GameScreenData.Data(
                 gameDetails = gameDetails,
-                dealDetails = persistentListOf(store to gameDeal)
+                dealDetails = persistentListOf(StoreDealPair(store = store, deal = gameDeal))
             )
         )
 
@@ -180,7 +180,7 @@ class GameScreenTest {
         every { viewModel.uiState } returns MutableStateFlow(
             GameViewModel.GameScreenData.Data(
                 gameDetails = gameDetails,
-                dealDetails = persistentListOf(store to gameDeal)
+                dealDetails = persistentListOf(StoreDealPair(store = store, deal = gameDeal))
             )
         )
 

--- a/feature/game/src/commonMain/kotlin/pm/bam/gamedeals/feature/game/ui/GameScreen.kt
+++ b/feature/game/src/commonMain/kotlin/pm/bam/gamedeals/feature/game/ui/GameScreen.kt
@@ -142,9 +142,9 @@ private fun CompactGameDealsDetails(
         ) {
             data.dealDetails.forEach {
                 StoreGameDealRow(
-                    store = it.first,
+                    store = it.store,
                     gameInfo = data.gameDetails.info,
-                    deal = it.second,
+                    deal = it.deal,
                     goToWeb = goToWeb,
                     onShareDeal = onShareDeal,
                 )
@@ -172,9 +172,9 @@ private fun WideGameDealsDetails(
         ) {
             data.dealDetails.forEach {
                 StoreGameDealRow(
-                    store = it.first,
+                    store = it.store,
                     gameInfo = data.gameDetails.info,
-                    deal = it.second,
+                    deal = it.deal,
                     goToWeb = goToWeb,
                     onShareDeal = onShareDeal,
                 )
@@ -427,20 +427,26 @@ private fun GameScreenContent(
 
 
 private val previewGameDealDetails = persistentListOf(
-    PreviewStore to PreviewGameDeal,
-    PreviewStore.copy(storeID = 11, storeName = "Humble Store") to PreviewGameDeal.copy(
-        storeID = 11,
-        dealID = "deal-2",
-        priceValue = 8.49,
-        priceDenominated = "$8.49",
-        savings = 78,
+    StoreDealPair(store = PreviewStore, deal = PreviewGameDeal),
+    StoreDealPair(
+        store = PreviewStore.copy(storeID = 11, storeName = "Humble Store"),
+        deal = PreviewGameDeal.copy(
+            storeID = 11,
+            dealID = "deal-2",
+            priceValue = 8.49,
+            priceDenominated = "$8.49",
+            savings = 78,
+        ),
     ),
-    PreviewStore.copy(storeID = 7, storeName = "GOG") to PreviewGameDeal.copy(
-        storeID = 7,
-        dealID = "deal-3",
-        priceValue = 11.99,
-        priceDenominated = "$11.99",
-        savings = 60,
+    StoreDealPair(
+        store = PreviewStore.copy(storeID = 7, storeName = "GOG"),
+        deal = PreviewGameDeal.copy(
+            storeID = 7,
+            dealID = "deal-3",
+            priceValue = 11.99,
+            priceDenominated = "$11.99",
+            savings = 60,
+        ),
     ),
 )
 

--- a/feature/game/src/commonMain/kotlin/pm/bam/gamedeals/feature/game/ui/GameViewModel.kt
+++ b/feature/game/src/commonMain/kotlin/pm/bam/gamedeals/feature/game/ui/GameViewModel.kt
@@ -125,7 +125,7 @@ internal class GameViewModel(
             .flatMapLatest { gamesRepository.getGameDetails(it).toFlow() }
             .flatMapLatest { details ->
                 details.deals
-                    .map { deal -> storesRepository.getStore(deal.storeID) to deal }
+                    .map { deal -> StoreDealPair(store = storesRepository.getStore(deal.storeID), deal = deal) }
                     .let { dealDetails -> GameScreenData.Data(details, dealDetails.toImmutableList()) }
                     .toFlow<GameScreenData>()
             }
@@ -145,7 +145,7 @@ internal class GameViewModel(
         @Immutable
         data class Data(
             val gameDetails: GameDetails,
-            val dealDetails: ImmutableList<Pair<Store, GameDetails.GameDeal>>
+            val dealDetails: ImmutableList<StoreDealPair>
         ) : GameScreenData()
     }
 }

--- a/feature/game/src/commonMain/kotlin/pm/bam/gamedeals/feature/game/ui/StoreDealPair.kt
+++ b/feature/game/src/commonMain/kotlin/pm/bam/gamedeals/feature/game/ui/StoreDealPair.kt
@@ -1,0 +1,18 @@
+package pm.bam.gamedeals.feature.game.ui
+
+import androidx.compose.runtime.Immutable
+import pm.bam.gamedeals.domain.models.GameDetails
+import pm.bam.gamedeals.domain.models.Store
+
+/**
+ * Compose-stable wrapper around a (Store, GameDeal) tuple.
+ *
+ * Replaces `kotlin.Pair<Store, GameDetails.GameDeal>` in composable parameter
+ * types so that wrapping list types (e.g. `ImmutableList<StoreDealPair>`) are
+ * considered stable by the Compose compiler and skipping can apply.
+ */
+@Immutable
+data class StoreDealPair(
+    val store: Store,
+    val deal: GameDetails.GameDeal,
+)

--- a/feature/game/src/commonTest/kotlin/pm/bam/gamedeals/feature/game/ui/GameViewModelTest.kt
+++ b/feature/game/src/commonTest/kotlin/pm/bam/gamedeals/feature/game/ui/GameViewModelTest.kt
@@ -106,7 +106,7 @@ class GameViewModelTest : MainDispatcherTest() {
 
         assertEquals(2, emissions.size)
         assertEquals(GameViewModel.GameScreenData.Loading, emissions.first())
-        assertEquals(GameViewModel.GameScreenData.Data(details, persistentListOf(store to gameDeal)), emissions.second())
+        assertEquals(GameViewModel.GameScreenData.Data(details, persistentListOf(StoreDealPair(store = store, deal = gameDeal))), emissions.second())
     }
 
     @Test
@@ -129,12 +129,12 @@ class GameViewModelTest : MainDispatcherTest() {
         delay(1200)
 
         assertEquals(2, emissions.size)
-        assertEquals(GameViewModel.GameScreenData.Data(details, persistentListOf(store to gameDeal)), emissions.second())
+        assertEquals(GameViewModel.GameScreenData.Data(details, persistentListOf(StoreDealPair(store = store, deal = gameDeal))), emissions.second())
 
         viewModel.reloadGameDetails()
 
         assertEquals(4, emissions.size)
         assertEquals(GameViewModel.GameScreenData.Loading, emissions.third())
-        assertEquals(GameViewModel.GameScreenData.Data(details, persistentListOf(store to gameDeal)), emissions.fourth())
+        assertEquals(GameViewModel.GameScreenData.Data(details, persistentListOf(StoreDealPair(store = store, deal = gameDeal))), emissions.fourth())
     }
 }


### PR DESCRIPTION
Closes #147.

## Summary
- `kotlin.Pair` is unstable in Compose, so any composable parameter typed `ImmutableList<Pair<A, B>>` (or `List<Pair<A, B>>`) loses skipping because the list's type argument drags it back to unstable.
- Introduces two `@Immutable` wrapper data classes — `StoreDealPair(store, deal)` in `:feature:game` and `StoreCheaperStorePair(store, cheaperStore)` in `:common:ui` — and uses them in place of `Pair` at:
  - `GameViewModel.GameScreenData.Data.dealDetails: ImmutableList<StoreDealPair>` and its `GameScreen` consumers / previews.
  - `DealBottomSheetData.DealDetailsData.cheaperStores: List<StoreCheaperStorePair>`, populated in `DealDetailsController` and consumed in `DealBottomSheet` / previews.
- All `.first` / `.second` consumer references renamed to `.store` / `.deal` / `.cheaperStore` accordingly, including in instrumented and unit tests.

Follows the same `@Immutable + ImmutableList` pattern recorded in `L-2026-05-02-02`.

## Test plan
- [x] `./gradlew :feature:game:testDebugUnitTest :common:ui:testDebugUnitTest`
- [x] `./gradlew :feature:game:compileKotlinIosSimulatorArm64 :common:ui:compileKotlinIosSimulatorArm64`
- [x] `./gradlew :feature:game:compileDebugAndroidTestKotlinAndroid :common:ui:compileDebugAndroidTestKotlinAndroid` (instrumented test sources compile against renamed fields)

🤖 Generated with [Claude Code](https://claude.com/claude-code)