### PR TITLE
refactor(app): dispatch Sentry.init off Main via applicationScope

### DIFF
--- a/app/src/main/java/pm/bam/gamedeals/GameDealsApplication.kt
+++ b/app/src/main/java/pm/bam/gamedeals/GameDealsApplication.kt
@@ -127,11 +127,24 @@ class GameDealsApplication : Application(), SingletonImageLoader.Factory {
         }
     }
 
+    /**
+     * Initialise the Sentry SDK off the Main thread.
+     *
+     * The empty-DSN early-return is kept at the top so debug/CI builds stay
+     * zero-cost — we don't even wake [applicationScope] in that case.
+     *
+     * When a DSN is configured, the synchronous `Sentry.init` bootstrap is
+     * dispatched onto [applicationScope] (IO dispatcher) so it doesn't add
+     * cold-start cost to `Application.onCreate`. Fire-and-forget: any failure
+     * inside `Sentry.init` should not crash the app.
+     */
     private fun initSentry() {
         if (SENTRY_DSN.isEmpty()) return
-        Sentry.init { options ->
-            options.dsn = SENTRY_DSN
-            options.debug = isDebuggable()
+        applicationScope.launch {
+            Sentry.init { options ->
+                options.dsn = SENTRY_DSN
+                options.debug = isDebuggable()
+            }
         }
     }
 


### PR DESCRIPTION
Closes #151.

## Summary
- `GameDealsApplication.initSentry()` previously ran the synchronous `Sentry.init { ... }` SDK bootstrap directly on Main during `Application.onCreate`. Dormant today because `SENTRY_DSN = ""` causes an early return — but a real DSN would add cold-start cost on the UI thread.
- Wraps the `Sentry.init` body in `applicationScope.launch { ... }` so the bootstrap runs on `Dispatchers.IO`. Reuses the application-scoped `CoroutineScope` hoisted by #153 (PR #160), which was set up precisely for this kind of cold-start initializer.
- Preserves the `if (SENTRY_DSN.isEmpty()) return` early-return at the top of `initSentry()` so debug/CI builds stay zero-cost — the scope isn't even woken when the DSN is empty.
- Call site in `onCreate()` is unchanged.

## Test plan
- [x] `./gradlew :app:compileDebugKotlin` (JBR 21) — BUILD SUCCESSFUL
- [ ] Manual smoke: cold-start the debug build, confirm app launches cleanly (DSN is empty, so `Sentry.init` should not run).

🤖 Generated with [Claude Code](https://claude.com/claude-code)