### PR TITLE
feat(remote): add parameterless httpClient() overload for Swift interop

### DIFF
--- a/remote/src/commonMain/kotlin/pm/bam/gamedeals/remote/logic/HttpClientFactory.kt
+++ b/remote/src/commonMain/kotlin/pm/bam/gamedeals/remote/logic/HttpClientFactory.kt
@@ -12,3 +12,11 @@ import io.ktor.client.HttpClientConfig
  * to get a fully-configured engine-bound client.
  */
 expect fun httpClient(block: HttpClientConfig<*>.() -> Unit = {}): HttpClient
+
+/**
+ * Parameterless overload for Swift consumers. Kotlin/Native does not expose
+ * Kotlin default arguments to Swift, so callers on the iOS side cannot invoke
+ * `httpClient()` without supplying a closure unless this overload exists.
+ * Delegates to the `expect` form with an empty config block.
+ */
+fun httpClient(): HttpClient = httpClient {}


### PR DESCRIPTION
Closes #152.

## Summary
- `remote/src/commonMain/kotlin/pm/bam/gamedeals/remote/logic/HttpClientFactory.kt` declares `expect fun httpClient(block: HttpClientConfig<*>.() -> Unit = {}): HttpClient`. Kotlin/Native does not expose Kotlin default arguments to Swift, so iOS-side Swift consumers cannot call `httpClient()` without supplying an explicit empty closure.
- This PR adds a commonMain-only zero-arg overload that delegates to the `expect` form: `fun httpClient(): HttpClient = httpClient {}`.
- No runtime impact for existing Kotlin callers — they continue to hit the default-arg path on the `expect` declaration. The value is purely Swift-API surface area (consistent with `L-2026-05-15-01` — K/N exposes category extensions and default args differently for Swift).
- The `actual` declarations (`HttpClientFactory.android.kt`, `HttpClientFactory.ios.kt`) are intentionally untouched per the project convention of keeping `actual` signatures minimal; the overload lives on the common-side surface area only.

## Test plan
- [x] `./gradlew :remote:compileDebugKotlinAndroid` — passes
- [x] `./gradlew :remote:compileKotlinIosSimulatorArm64` — passes
- [x] `./gradlew :remote:testDebugUnitTest` — passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)