### PR TITLE
feat(game-page): ITAD info/v2 enrichment + bundles-for-game (#293)

### DIFF
--- a/domain/src/commonMain/kotlin/pm/bam/gamedeals/domain/models/GameMeta.kt
+++ b/domain/src/commonMain/kotlin/pm/bam/gamedeals/domain/models/GameMeta.kt
@@ -1,0 +1,68 @@
+@file:UseSerializers(ImmutableListSerializer::class)
+
+package pm.bam.gamedeals.domain.models
+
+
+import androidx.compose.runtime.Immutable
+import kotlinx.collections.immutable.ImmutableList
+import kotlinx.collections.immutable.persistentListOf
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.UseSerializers
+import pm.bam.gamedeals.domain.utils.ImmutableListSerializer
+
+/**
+ * Catalogue + live-signal metadata for a game, sourced from ITAD `/games/info/v2` (epic #291, Phase 1).
+ *
+ * Distinct from [GameDetails] (deals/prices) and [IgdbGame] (description/screenshots/similar games): this
+ * carries the fields the app previously discarded out of `info/v2` — developers/publishers, tags, release
+ * date — plus the redesigned Game Page's live signals: storefront/critic [reviews], waitlist/collection
+ * [stats], and current [players] counts.
+ *
+ * Source-neutral and `@Serializable` so it can be cached as a region-agnostic JSON blob like [GameDetails]
+ * (caching wired in Phase 3). [players] is volatile and is cached separately / at a shorter TTL.
+ */
+@Immutable
+@Serializable
+data class GameMeta(
+    val gameId: String,
+    val steamAppId: Int? = null,
+    val releaseDate: String? = null,
+    val developers: ImmutableList<String> = persistentListOf(),
+    val publishers: ImmutableList<String> = persistentListOf(),
+    val tags: ImmutableList<String> = persistentListOf(),
+    val reviews: ImmutableList<Review> = persistentListOf(),
+    val players: Players? = null,
+    val stats: Stats? = null,
+    val earlyAccess: Boolean = false,
+    val achievements: Boolean = false,
+    val tradingCards: Boolean = false,
+) {
+    /** A storefront/critic review score, e.g. Steam (% positive) or Metacritic (/100). [score] is the source's own scale. */
+    @Immutable
+    @Serializable
+    data class Review(
+        val source: String,
+        val score: Int? = null,
+        val count: Int? = null,
+        val url: String? = null,
+    )
+
+    /** Current player counts from ITAD `players` (recent / day / week / peak). Snapshot only — no history. */
+    @Immutable
+    @Serializable
+    data class Players(
+        val recent: Int? = null,
+        val day: Int? = null,
+        val week: Int? = null,
+        val peak: Int? = null,
+    )
+
+    /** ITAD global standing: catalogue [rank], and how many users have [waitlisted] / [collected] the game. */
+    @Immutable
+    @Serializable
+    data class Stats(
+        val rank: Int? = null,
+        val waitlisted: Int? = null,
+        val collected: Int? = null,
+    )
+}

--- a/domain/src/commonMain/kotlin/pm/bam/gamedeals/domain/source/DealsSource.kt
+++ b/domain/src/commonMain/kotlin/pm/bam/gamedeals/domain/source/DealsSource.kt
@@ -6,6 +6,7 @@ import pm.bam.gamedeals.domain.models.DealDetails
 import pm.bam.gamedeals.domain.models.DealsQuery
 import pm.bam.gamedeals.domain.models.Game
 import pm.bam.gamedeals.domain.models.GameDetails
+import pm.bam.gamedeals.domain.models.GameMeta
 import pm.bam.gamedeals.domain.models.PriceHistory
 import pm.bam.gamedeals.domain.models.SearchParameters
 import pm.bam.gamedeals.domain.models.Store
@@ -67,6 +68,21 @@ interface DealsSource {
      * return an empty list.
      */
     suspend fun fetchBundles(): List<Bundle>
+
+    /**
+     * Catalogue + live-signal metadata for a game (by its source game id), over ITAD `/games/info/v2`
+     * (epic #291, Phase 1) — developers/publishers, tags, release date, storefront/critic reviews,
+     * waitlist/collection stats, and current player counts. Powers the redesigned Game Page's Stats tab
+     * and header. Providers without this data return a [GameMeta] with empty collections / null signals.
+     */
+    suspend fun fetchGameMeta(gameId: String): GameMeta
+
+    /**
+     * The bundles that contain the given game (by its source game id), over ITAD `/games/bundles/v2`
+     * (epic #291, Phase 1) — drives the Game Page's "Found in bundles" section. Providers without this
+     * data return an empty list.
+     */
+    suspend fun fetchBundlesForGame(gameId: String): List<Bundle>
 
     suspend fun fetchStores(): List<Store>
 }

--- a/remote/itad/src/commonMain/kotlin/pm/bam/gamedeals/remote/itad/ItadSourceImpl.kt
+++ b/remote/itad/src/commonMain/kotlin/pm/bam/gamedeals/remote/itad/ItadSourceImpl.kt
@@ -9,6 +9,7 @@ import pm.bam.gamedeals.domain.models.DealDetails
 import pm.bam.gamedeals.domain.models.DealsQuery
 import pm.bam.gamedeals.domain.models.Game
 import pm.bam.gamedeals.domain.models.GameDetails
+import pm.bam.gamedeals.domain.models.GameMeta
 import pm.bam.gamedeals.domain.models.PriceHistory
 import pm.bam.gamedeals.domain.models.SearchParameters
 import pm.bam.gamedeals.domain.models.Store
@@ -25,6 +26,7 @@ import pm.bam.gamedeals.remote.itad.mappers.toDeal
 import pm.bam.gamedeals.remote.itad.mappers.toDealDetails
 import pm.bam.gamedeals.remote.itad.mappers.toGame
 import pm.bam.gamedeals.remote.itad.mappers.toGameDetails
+import pm.bam.gamedeals.remote.itad.mappers.toGameMeta
 import pm.bam.gamedeals.remote.itad.mappers.toItadDeal
 import pm.bam.gamedeals.remote.itad.mappers.toItadGamePrices
 import pm.bam.gamedeals.remote.itad.mappers.toItadGameSearchResult
@@ -132,6 +134,20 @@ internal class ItadSourceImpl(
 
     override suspend fun fetchBundles(): List<Bundle> =
         bundlesApi.getBundles(country = regionRepository.getSelectedCountryCode())
+            .log(logger, tag = TAG)
+            .mapAnyFailure { remoteExceptionTransformer.transformApiException(this) }
+            .getOrThrow()
+            .map { it.toBundle() }
+
+    override suspend fun fetchGameMeta(gameId: String): GameMeta =
+        gamesApi.getInfo(gameId)
+            .log(logger, tag = TAG)
+            .mapAnyFailure { remoteExceptionTransformer.transformApiException(this) }
+            .getOrThrow()
+            .toGameMeta()
+
+    override suspend fun fetchBundlesForGame(gameId: String): List<Bundle> =
+        gamesApi.getBundlesForGame(gameId)
             .log(logger, tag = TAG)
             .mapAnyFailure { remoteExceptionTransformer.transformApiException(this) }
             .getOrThrow()

--- a/remote/itad/src/commonMain/kotlin/pm/bam/gamedeals/remote/itad/api/ItadGamesApi.kt
+++ b/remote/itad/src/commonMain/kotlin/pm/bam/gamedeals/remote/itad/api/ItadGamesApi.kt
@@ -10,6 +10,8 @@ import io.ktor.client.request.setBody
 import io.ktor.http.ContentType
 import io.ktor.http.contentType
 import kotlinx.coroutines.CancellationException
+import pm.bam.gamedeals.remote.itad.models.RemoteItadBundle
+import pm.bam.gamedeals.remote.itad.models.RemoteItadGameInfo
 import pm.bam.gamedeals.remote.itad.models.RemoteItadGamePrices
 import pm.bam.gamedeals.remote.itad.models.RemoteItadHistoryEntry
 import pm.bam.gamedeals.remote.itad.models.RemoteItadLookupResponse
@@ -34,12 +36,25 @@ class ItadGamesApi(private val httpClient: HttpClient) {
         ApiResponse.exception(t)
     }
 
-    /** Basic game info (title + assets) by UUID — `/games/info/v2` returns the same shape as search. */
-    suspend fun getInfo(id: String): ApiResponse<RemoteItadSearchGame> = try {
+    /** Full game info by UUID — `/games/info/v2` returns the rich [RemoteItadGameInfo] (header + catalogue + live signals). */
+    suspend fun getInfo(id: String): ApiResponse<RemoteItadGameInfo> = try {
         ApiResponse.Success(
             httpClient.get("/games/info/v2") {
                 parameter("id", id)
-            }.body<RemoteItadSearchGame>()
+            }.body<RemoteItadGameInfo>()
+        )
+    } catch (e: CancellationException) {
+        throw e
+    } catch (t: Throwable) {
+        ApiResponse.exception(t)
+    }
+
+    /** Bundles that contain the given game — `/games/bundles/v2?id=<uuid>` returns the same bundle shape as `/bundles/v1`. */
+    suspend fun getBundlesForGame(id: String): ApiResponse<List<RemoteItadBundle>> = try {
+        ApiResponse.Success(
+            httpClient.get("/games/bundles/v2") {
+                parameter("id", id)
+            }.body<List<RemoteItadBundle>>()
         )
     } catch (e: CancellationException) {
         throw e

--- a/remote/itad/src/commonMain/kotlin/pm/bam/gamedeals/remote/itad/mappers/ItadDomainMappers.kt
+++ b/remote/itad/src/commonMain/kotlin/pm/bam/gamedeals/remote/itad/mappers/ItadDomainMappers.kt
@@ -8,6 +8,7 @@ import pm.bam.gamedeals.domain.models.Deal
 import pm.bam.gamedeals.domain.models.DealDetails
 import pm.bam.gamedeals.domain.models.Game
 import pm.bam.gamedeals.domain.models.GameDetails
+import pm.bam.gamedeals.domain.models.GameMeta
 import pm.bam.gamedeals.domain.models.PriceHistory
 import pm.bam.gamedeals.remote.itad.models.ItadDeal
 import pm.bam.gamedeals.remote.itad.models.ItadGamePrices
@@ -15,6 +16,7 @@ import pm.bam.gamedeals.remote.itad.models.ItadGameSearchResult
 import pm.bam.gamedeals.remote.itad.models.ItadMoney
 import pm.bam.gamedeals.remote.itad.models.ItadPriceHistoryEntry
 import pm.bam.gamedeals.remote.itad.models.RemoteItadBundle
+import pm.bam.gamedeals.remote.itad.models.RemoteItadGameInfo
 import pm.bam.gamedeals.remote.itad.models.bestArt
 
 /**
@@ -123,6 +125,26 @@ internal fun RemoteItadBundle.toBundle(): Bundle {
         games = games,
     )
 }
+
+/**
+ * ITAD `/games/info/v2` → domain [GameMeta] (epic #291, Phase 1). Companies are flattened to their names
+ * (the UI shows names, not ITAD company ids); reviews/stats/players carry through one-to-one. Empty
+ * collections and null objects are preserved so the consumer can hide each section when ITAD omits it.
+ */
+internal fun RemoteItadGameInfo.toGameMeta(): GameMeta = GameMeta(
+    gameId = id,
+    steamAppId = appid,
+    releaseDate = releaseDate,
+    developers = developers.map { it.name }.toImmutableList(),
+    publishers = publishers.map { it.name }.toImmutableList(),
+    tags = tags.toImmutableList(),
+    reviews = reviews.map { GameMeta.Review(source = it.source, score = it.score, count = it.count, url = it.url) }.toImmutableList(),
+    players = players?.let { GameMeta.Players(recent = it.recent, day = it.day, week = it.week, peak = it.peak) },
+    stats = stats?.let { GameMeta.Stats(rank = it.rank, waitlisted = it.waitlisted, collected = it.collected) },
+    earlyAccess = earlyAccess,
+    achievements = achievements,
+    tradingCards = tradingCards,
+)
 
 internal fun ItadGameSearchResult.toGame(): Game = Game(
     gameID = id,

--- a/remote/itad/src/commonMain/kotlin/pm/bam/gamedeals/remote/itad/mappers/ItadMappers.kt
+++ b/remote/itad/src/commonMain/kotlin/pm/bam/gamedeals/remote/itad/mappers/ItadMappers.kt
@@ -10,6 +10,7 @@ import pm.bam.gamedeals.remote.itad.models.ItadPriceHistoryEntry
 import pm.bam.gamedeals.remote.itad.models.ItadShop
 import pm.bam.gamedeals.remote.itad.models.RemoteItadDealEntry
 import pm.bam.gamedeals.remote.itad.models.RemoteItadDealsGame
+import pm.bam.gamedeals.remote.itad.models.RemoteItadGameInfo
 import pm.bam.gamedeals.remote.itad.models.RemoteItadGamePrices
 import pm.bam.gamedeals.remote.itad.models.RemoteItadHistoryEntry
 import pm.bam.gamedeals.remote.itad.models.RemoteItadPrice
@@ -83,6 +84,16 @@ internal fun RemoteItadSearchGame.toItadGameSearchResult(steamAppId: Int? = null
         title = title,
         slug = slug,
         steamAppId = steamAppId,
+        boxart = assets.bestArt(),
+    )
+
+/** `/games/info/v2` carries the same header fields as a search game, so reduce it to the lightweight identity used for deal/game headers. */
+internal fun RemoteItadGameInfo.toItadGameSearchResult(): ItadGameSearchResult =
+    ItadGameSearchResult(
+        id = id,
+        title = title,
+        slug = slug,
+        steamAppId = appid,
         boxart = assets.bestArt(),
     )
 

--- a/remote/itad/src/commonMain/kotlin/pm/bam/gamedeals/remote/itad/models/RemoteItadModels.kt
+++ b/remote/itad/src/commonMain/kotlin/pm/bam/gamedeals/remote/itad/models/RemoteItadModels.kt
@@ -64,6 +64,63 @@ data class RemoteItadLookupResponse(
     @SerialName("game") val game: RemoteItadSearchGame? = null,
 )
 
+// --- /games/info/v2 (the rich game-info shape; superset of the search game) ---
+@Serializable
+data class RemoteItadCompanyRef(
+    @SerialName("id") val id: Int? = null,
+    @SerialName("name") val name: String,
+)
+
+@Serializable
+data class RemoteItadReview(
+    @SerialName("score") val score: Int? = null,
+    @SerialName("source") val source: String,
+    @SerialName("count") val count: Int? = null,
+    @SerialName("url") val url: String? = null,
+)
+
+@Serializable
+data class RemoteItadStats(
+    @SerialName("rank") val rank: Int? = null,
+    @SerialName("waitlisted") val waitlisted: Int? = null,
+    @SerialName("collected") val collected: Int? = null,
+)
+
+@Serializable
+data class RemoteItadPlayers(
+    @SerialName("recent") val recent: Int? = null,
+    @SerialName("day") val day: Int? = null,
+    @SerialName("week") val week: Int? = null,
+    @SerialName("peak") val peak: Int? = null,
+)
+
+/**
+ * `/games/info/v2` — the full game-info object. A superset of [RemoteItadSearchGame]: the same
+ * id/slug/title/assets header plus catalogue metadata (developers, publishers, tags, release date) and
+ * the live signals the redesigned Game Page surfaces (storefront/critic [reviews], waitlist/collection
+ * [stats], current [players] counts). `ignoreUnknownKeys = true` tolerates ITAD's further extras.
+ */
+@Serializable
+data class RemoteItadGameInfo(
+    @SerialName("id") val id: String,
+    @SerialName("slug") val slug: String? = null,
+    @SerialName("title") val title: String,
+    @SerialName("type") val type: String? = null,
+    @SerialName("mature") val mature: Boolean? = null,
+    @SerialName("assets") val assets: RemoteItadGameAssets? = null,
+    @SerialName("appid") val appid: Int? = null,
+    @SerialName("earlyAccess") val earlyAccess: Boolean = false,
+    @SerialName("achievements") val achievements: Boolean = false,
+    @SerialName("tradingCards") val tradingCards: Boolean = false,
+    @SerialName("releaseDate") val releaseDate: String? = null,
+    @SerialName("tags") val tags: List<String> = emptyList(),
+    @SerialName("developers") val developers: List<RemoteItadCompanyRef> = emptyList(),
+    @SerialName("publishers") val publishers: List<RemoteItadCompanyRef> = emptyList(),
+    @SerialName("reviews") val reviews: List<RemoteItadReview> = emptyList(),
+    @SerialName("stats") val stats: RemoteItadStats? = null,
+    @SerialName("players") val players: RemoteItadPlayers? = null,
+)
+
 // --- /deals/v2 and the deal entries reused by /games/prices/v3 ---
 @Serializable
 data class RemoteItadDealEntry(

--- a/remote/itad/src/commonTest/kotlin/pm/bam/gamedeals/remote/itad/ItadSourceImplTest.kt
+++ b/remote/itad/src/commonTest/kotlin/pm/bam/gamedeals/remote/itad/ItadSourceImplTest.kt
@@ -82,6 +82,7 @@ class ItadSourceImplTest {
                 "/games/lookup/v1" -> LOOKUP_BODY
                 "/games/info/v2" -> INFO_BODY
                 "/bundles/v1" -> BUNDLES_BODY
+                "/games/bundles/v2" -> BUNDLES_BODY
                 else -> ""
             }
             respond(
@@ -356,6 +357,47 @@ class ItadSourceImplTest {
     }
 
     @Test
+    fun fetchGameMeta_maps_catalogue_reviews_stats_and_players_from_info() = runTest {
+        val meta = impl.fetchGameMeta("uuid-1")
+
+        assertEquals("uuid-1", meta.gameId)
+        assertEquals(1240, meta.steamAppId) // from info `appid`
+        assertEquals("2021-12-08", meta.releaseDate)
+        assertEquals(listOf("343 Industries"), meta.developers) // companies flattened to names
+        assertEquals(listOf("Xbox Game Studios"), meta.publishers)
+        assertEquals(listOf("Shooter", "Sci-fi"), meta.tags)
+        assertEquals(2, meta.reviews.size)
+        assertEquals("steam", meta.reviews.first().source)
+        assertEquals(85, meta.reviews.first().score)
+        assertEquals(12345, meta.reviews.first().count)
+        assertEquals(16763, meta.players?.recent)
+        assertEquals(30000, meta.players?.peak)
+        assertEquals(5, meta.stats?.rank)
+        assertEquals(1000, meta.stats?.waitlisted)
+        assertEquals(5000, meta.stats?.collected)
+        assertTrue(meta.achievements)
+        assertTrue(meta.tradingCards)
+        assertFalse(meta.earlyAccess)
+
+        val recorded = recordedRequests.single().url
+        assertEquals("/games/info/v2", recorded.encodedPath)
+        assertEquals("uuid-1", recorded.parameters["id"])
+    }
+
+    @Test
+    fun fetchBundlesForGame_maps_the_bundles_containing_the_game() = runTest {
+        val bundles = impl.fetchBundlesForGame("uuid-1")
+
+        assertEquals(1, bundles.size)
+        assertEquals(16232, bundles.first().id)
+        assertEquals("Humble Choice (June 2026)", bundles.first().title)
+
+        val recorded = recordedRequests.single().url
+        assertEquals("/games/bundles/v2", recorded.encodedPath)
+        assertEquals("uuid-1", recorded.parameters["id"])
+    }
+
+    @Test
     fun itadHttpClient_sends_the_api_key_header_to_the_itad_host() = runTest {
         val recorded = mutableListOf<HttpRequestData>()
         val engine = MockEngine { request ->
@@ -497,9 +539,29 @@ class ItadSourceImplTest {
             ]
           }"""
 
-        // language=JSON — /games/info/v2 returns a single game object (title + assets).
-        private const val INFO_BODY =
-            """{ "id": "uuid-1", "slug": "halo", "title": "Halo", "assets": { "boxart": "info-box.png", "banner400": "info-banner400.png" } }"""
+        // language=JSON — /games/info/v2 returns the rich game-info object (header + catalogue + live signals).
+        private const val INFO_BODY = """{
+            "id": "uuid-1",
+            "slug": "halo",
+            "title": "Halo",
+            "type": "game",
+            "mature": false,
+            "assets": { "boxart": "info-box.png", "banner400": "info-banner400.png" },
+            "appid": 1240,
+            "earlyAccess": false,
+            "achievements": true,
+            "tradingCards": true,
+            "releaseDate": "2021-12-08",
+            "tags": [ "Shooter", "Sci-fi" ],
+            "developers": [ { "id": 1, "name": "343 Industries" } ],
+            "publishers": [ { "id": 2, "name": "Xbox Game Studios" } ],
+            "reviews": [
+              { "score": 85, "source": "steam", "count": 12345, "url": "https://steam/reviews" },
+              { "score": 87, "source": "Metacritic", "count": 42, "url": "https://mc/halo" }
+            ],
+            "stats": { "rank": 5, "waitlisted": 1000, "collected": 5000 },
+            "players": { "recent": 16763, "day": 16967, "week": 20000, "peak": 30000 }
+          }"""
 
         // language=JSON
         private const val PRICES_BODY = """[


### PR DESCRIPTION
Phase 1 of the Unified Game Page epic (#291). Reclaims the ITAD `/games/info/v2` fields the app
previously discarded, and adds "bundles containing this game" — the data layer the redesigned Game Page's
header + Stats tab + "Found in bundles" section will consume.

## Changes
- **`RemoteItadGameInfo`** transport DTO (+ `RemoteItadCompanyRef`/`RemoteItadReview`/`RemoteItadStats`/`RemoteItadPlayers`) — the full `info/v2` shape: developers, publishers, tags, releaseDate, reviews, stats, players, appid, earlyAccess, achievements, tradingCards.
- **`GameMeta`** domain model (`@Serializable`, source-neutral) for that metadata + live signals.
- Mappers: `RemoteItadGameInfo.toGameMeta()` (DTO→domain) and a `toItadGameSearchResult()` overload so the existing title/boxart header path keeps working.
- `ItadGamesApi.getInfo` now returns the rich type; new `getBundlesForGame(id)` → `/games/bundles/v2`.
- `DealsSource` gains `fetchGameMeta(gameId)` + `fetchBundlesForGame(gameId)`; implemented in `ItadSourceImpl`.
- Tests: enriched `info/v2` fixture + coverage for `fetchGameMeta` and `fetchBundlesForGame`.

Caching of this data (players at a shorter TTL) is wired in Phase 3 (#295).

Part of #291. Closes #293.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
