### PR TITLE
feat(game-page): IGDB DLCs/expansions + HowLongToBeat (#294)

### DIFF
--- a/domain/src/commonMain/kotlin/pm/bam/gamedeals/domain/models/IgdbGame.kt
+++ b/domain/src/commonMain/kotlin/pm/bam/gamedeals/domain/models/IgdbGame.kt
@@ -23,6 +23,14 @@ data class IgdbGame(
     val involvedCompanies: ImmutableList<IgdbCompanyRole> = persistentListOf(),
     val websites: ImmutableList<IgdbWebsite> = persistentListOf(),
     val similarGames: ImmutableList<IgdbSimilarGame> = persistentListOf(),
+    val dlcs: ImmutableList<IgdbSimilarGame> = persistentListOf(),
+    val expansions: ImmutableList<IgdbSimilarGame> = persistentListOf(),
+    /**
+     * HowLongToBeat-style completion estimates (epic #291, Phase 2). Fetched separately from IGDB's
+     * `/v4/game_time_to_beats` endpoint (not part of the games dot-expansion) and merged in by the
+     * consumer, so it is null on a bare game lookup until enriched.
+     */
+    val timeToBeat: IgdbTimeToBeat? = null,
     val steamAppId: Int? = null,
 ) {
 
@@ -52,5 +60,14 @@ data class IgdbGame(
         val id: Long,
         val name: String,
         val coverImageId: String?,
+    )
+
+    /** HowLongToBeat completion estimates in **seconds** (IGDB `game_time_to_beats`); UI formats to hours. */
+    @Immutable
+    data class IgdbTimeToBeat(
+        val hastily: Long? = null,
+        val normally: Long? = null,
+        val completely: Long? = null,
+        val count: Long? = null,
     )
 }

--- a/domain/src/commonMain/kotlin/pm/bam/gamedeals/domain/repositories/igdb/IgdbRepository.kt
+++ b/domain/src/commonMain/kotlin/pm/bam/gamedeals/domain/repositories/igdb/IgdbRepository.kt
@@ -10,6 +10,7 @@ interface IgdbRepository {
     suspend fun fetchGameDetailsByIgdbId(igdbGameId: Long): IgdbGame?
     suspend fun fetchGameDetailsByTitle(title: String): IgdbGame?
     suspend fun fetchSearchCandidatesByTitle(title: String): ImmutableList<IgdbGame.IgdbSimilarGame>
+    suspend fun fetchTimeToBeat(igdbGameId: Long): IgdbGame.IgdbTimeToBeat?
 }
 
 internal class IgdbRepositoryImpl(
@@ -30,4 +31,7 @@ internal class IgdbRepositoryImpl(
 
     override suspend fun fetchSearchCandidatesByTitle(title: String): ImmutableList<IgdbGame.IgdbSimilarGame> =
         igdbSource.fetchSearchCandidatesByTitle(title)
+
+    override suspend fun fetchTimeToBeat(igdbGameId: Long): IgdbGame.IgdbTimeToBeat? =
+        igdbSource.fetchTimeToBeat(igdbGameId)
 }

--- a/domain/src/commonMain/kotlin/pm/bam/gamedeals/domain/source/IgdbSource.kt
+++ b/domain/src/commonMain/kotlin/pm/bam/gamedeals/domain/source/IgdbSource.kt
@@ -47,4 +47,11 @@ interface IgdbSource {
      * never null.
      */
     suspend fun fetchSearchCandidatesByTitle(title: String): ImmutableList<IgdbGame.IgdbSimilarGame>
+
+    /**
+     * HowLongToBeat-style completion estimates for an IGDB game (epic #291, Phase 2), from the dedicated
+     * `/v4/game_time_to_beats` endpoint. Fetched separately from the game lookup and merged onto
+     * [IgdbGame.timeToBeat] by the consumer. Returns null when IGDB has no completion data for the game.
+     */
+    suspend fun fetchTimeToBeat(igdbGameId: Long): IgdbGame.IgdbTimeToBeat?
 }

--- a/remote/igdb/src/commonMain/kotlin/pm/bam/gamedeals/remote/igdb/IgdbSourceImpl.kt
+++ b/remote/igdb/src/commonMain/kotlin/pm/bam/gamedeals/remote/igdb/IgdbSourceImpl.kt
@@ -12,6 +12,7 @@ import pm.bam.gamedeals.remote.exceptions.RemoteExceptionTransformer
 import pm.bam.gamedeals.remote.igdb.api.IgdbGamesApi
 import pm.bam.gamedeals.remote.igdb.mappers.toIgdbCandidateList
 import pm.bam.gamedeals.remote.igdb.mappers.toIgdbGameOrNull
+import pm.bam.gamedeals.remote.igdb.mappers.toIgdbTimeToBeatOrNull
 import pm.bam.gamedeals.remote.igdb.mappers.toReleaseOrNull
 import pm.bam.gamedeals.remote.logic.log
 import pm.bam.gamedeals.remote.logic.mapAnyFailure
@@ -96,6 +97,13 @@ internal class IgdbSourceImpl(
             .getOrThrow()
             .toIgdbCandidateList()
     }
+
+    override suspend fun fetchTimeToBeat(igdbGameId: Long): IgdbGame.IgdbTimeToBeat? =
+        igdbGamesApi.fetchTimeToBeat(igdbGameId)
+            .log(logger, tag = TAG)
+            .mapAnyFailure { remoteExceptionTransformer.transformApiException(this) }
+            .getOrThrow()
+            .toIgdbTimeToBeatOrNull()
 
     internal companion object {
         internal const val NEW_RELEASES_LIMIT = 20

--- a/remote/igdb/src/commonMain/kotlin/pm/bam/gamedeals/remote/igdb/api/IgdbGamesApi.kt
+++ b/remote/igdb/src/commonMain/kotlin/pm/bam/gamedeals/remote/igdb/api/IgdbGamesApi.kt
@@ -10,6 +10,7 @@ import io.ktor.http.contentType
 import kotlinx.coroutines.CancellationException
 import pm.bam.gamedeals.remote.igdb.models.RemoteExternalGameLookup
 import pm.bam.gamedeals.remote.igdb.models.RemoteIgdbGame
+import pm.bam.gamedeals.remote.igdb.models.RemoteIgdbTimeToBeat
 
 /**
  * IGDB endpoints. IGDB uses Apicalypse — a plain-text query language sent as the request body.
@@ -147,6 +148,24 @@ class IgdbGamesApi(private val httpClient: HttpClient) {
         ApiResponse.exception(t)
     }
 
+    /**
+     * HowLongToBeat-style completion estimates for a game (epic #291, Phase 2). IGDB exposes these on the
+     * dedicated `/v4/game_time_to_beats` endpoint (not via the games dot-expansion), keyed by `game_id`.
+     * Returns at most one row; empty list means IGDB has no time-to-beat data for that game.
+     */
+    suspend fun fetchTimeToBeat(igdbGameId: Long): ApiResponse<List<RemoteIgdbTimeToBeat>> = try {
+        ApiResponse.Success(
+            httpClient.post("/v4/game_time_to_beats") {
+                contentType(ContentType.Text.Plain)
+                setBody(buildTimeToBeatQuery(igdbGameId))
+            }.body()
+        )
+    } catch (e: CancellationException) {
+        throw e
+    } catch (t: Throwable) {
+        ApiResponse.exception(t)
+    }
+
     internal companion object {
         // IGDB migrated from the legacy `category` enum to a separate `external_game_source` reference
         // table (see /v4/external_game_sources). Steam still has id = 1 there. The old `category` field
@@ -166,6 +185,8 @@ class IgdbGamesApi(private val httpClient: HttpClient) {
                 game.involved_companies.company.name, game.involved_companies.developer, game.involved_companies.publisher, game.involved_companies.porting, game.involved_companies.supporting,
                 game.websites.url, game.websites.type.id, game.websites.type.type,
                 game.similar_games.id, game.similar_games.name, game.similar_games.cover.image_id,
+                game.dlcs.id, game.dlcs.name, game.dlcs.cover.image_id,
+                game.expansions.id, game.expansions.name, game.expansions.cover.image_id,
                 game.external_games.uid, game.external_games.external_game_source;
             where uid = "$steamAppId" & external_game_source = 1; limit 1;
         """.trimIndent()
@@ -183,6 +204,8 @@ class IgdbGamesApi(private val httpClient: HttpClient) {
                 involved_companies.company.name, involved_companies.developer, involved_companies.publisher, involved_companies.porting, involved_companies.supporting,
                 websites.url, websites.type.id, websites.type.type,
                 similar_games.id, similar_games.name, similar_games.cover.image_id,
+                dlcs.id, dlcs.name, dlcs.cover.image_id,
+                expansions.id, expansions.name, expansions.cover.image_id,
                 external_games.uid, external_games.external_game_source;
             where id = $igdbGameId; limit 1;
         """.trimIndent()
@@ -209,7 +232,9 @@ class IgdbGamesApi(private val httpClient: HttpClient) {
                     genres.name, themes.name,
                     involved_companies.company.name, involved_companies.developer, involved_companies.publisher, involved_companies.porting, involved_companies.supporting,
                     websites.url, websites.type.id, websites.type.type,
-                    similar_games.id, similar_games.name, similar_games.cover.image_id;
+                    similar_games.id, similar_games.name, similar_games.cover.image_id,
+                    dlcs.id, dlcs.name, dlcs.cover.image_id,
+                    expansions.id, expansions.name, expansions.cover.image_id;
                 where name = "$escaped"; limit 1;
             """.trimIndent()
         }
@@ -227,10 +252,16 @@ class IgdbGamesApi(private val httpClient: HttpClient) {
                     genres.name, themes.name,
                     involved_companies.company.name, involved_companies.developer, involved_companies.publisher, involved_companies.porting, involved_companies.supporting,
                     websites.url, websites.type.id, websites.type.type,
-                    similar_games.id, similar_games.name, similar_games.cover.image_id;
+                    similar_games.id, similar_games.name, similar_games.cover.image_id,
+                    dlcs.id, dlcs.name, dlcs.cover.image_id,
+                    expansions.id, expansions.name, expansions.cover.image_id;
                 limit 1;
             """.trimIndent()
         }
+
+        // `/v4/game_time_to_beats` is keyed by `game_id`; times come back in seconds.
+        internal fun buildTimeToBeatQuery(igdbGameId: Long): String =
+            """fields hastily, normally, completely, count; where game_id = $igdbGameId; limit 1;"""
 
         internal fun buildSearchCandidatesQuery(title: String): String {
             val escaped = escapeApicalypseString(title)

--- a/remote/igdb/src/commonMain/kotlin/pm/bam/gamedeals/remote/igdb/mappers/IgdbGameMappers.kt
+++ b/remote/igdb/src/commonMain/kotlin/pm/bam/gamedeals/remote/igdb/mappers/IgdbGameMappers.kt
@@ -9,6 +9,7 @@ import pm.bam.gamedeals.domain.models.igdbImageUrl
 import pm.bam.gamedeals.remote.igdb.models.RemoteIgdbGame
 import pm.bam.gamedeals.remote.igdb.models.RemoteIgdbInvolvedCompany
 import pm.bam.gamedeals.remote.igdb.models.RemoteIgdbSimilarGame
+import pm.bam.gamedeals.remote.igdb.models.RemoteIgdbTimeToBeat
 import pm.bam.gamedeals.remote.igdb.models.RemoteIgdbWebsite
 
 internal fun RemoteIgdbGame.toIgdbGame(): IgdbGame = IgdbGame(
@@ -28,6 +29,9 @@ internal fun RemoteIgdbGame.toIgdbGame(): IgdbGame = IgdbGame(
     involvedCompanies = involvedCompanies.flatMap { it.toRoles() }.toImmutableList(),
     websites = websites.mapNotNull { it.toIgdbWebsiteOrNull() }.toImmutableList(),
     similarGames = similarGames.mapNotNull { it.toIgdbSimilarGameOrNull() }.toImmutableList(),
+    dlcs = dlcs.mapNotNull { it.toIgdbSimilarGameOrNull() }.toImmutableList(),
+    expansions = expansions.mapNotNull { it.toIgdbSimilarGameOrNull() }.toImmutableList(),
+    // timeToBeat is fetched separately (/v4/game_time_to_beats) and merged by the consumer — left null here.
     steamAppId = externalGames
         .firstOrNull { it.externalGameSource == STEAM_EXTERNAL_GAME_SOURCE_ID }
         ?.uid
@@ -103,3 +107,10 @@ private fun RemoteIgdbSimilarGame.toIgdbSimilarGameOrNull(): IgdbGame.IgdbSimila
     val n = name ?: return null
     return IgdbGame.IgdbSimilarGame(id = id, name = n, coverImageId = cover?.imageId)
 }
+
+internal fun RemoteIgdbTimeToBeat.toIgdbTimeToBeat(): IgdbGame.IgdbTimeToBeat =
+    IgdbGame.IgdbTimeToBeat(hastily = hastily, normally = normally, completely = completely, count = count)
+
+/** First row of `/v4/game_time_to_beats`, or null when IGDB has no completion data for the game. */
+internal fun List<RemoteIgdbTimeToBeat>.toIgdbTimeToBeatOrNull(): IgdbGame.IgdbTimeToBeat? =
+    firstOrNull()?.toIgdbTimeToBeat()

--- a/remote/igdb/src/commonMain/kotlin/pm/bam/gamedeals/remote/igdb/models/RemoteIgdbGame.kt
+++ b/remote/igdb/src/commonMain/kotlin/pm/bam/gamedeals/remote/igdb/models/RemoteIgdbGame.kt
@@ -21,7 +21,22 @@ data class RemoteIgdbGame(
     @SerialName("involved_companies") val involvedCompanies: List<RemoteIgdbInvolvedCompany> = emptyList(),
     val websites: List<RemoteIgdbWebsite> = emptyList(),
     @SerialName("similar_games") val similarGames: List<RemoteIgdbSimilarGame> = emptyList(),
+    // DLCs and expansions share the similar-game shape (id, name, cover) so they map through the same path.
+    val dlcs: List<RemoteIgdbSimilarGame> = emptyList(),
+    val expansions: List<RemoteIgdbSimilarGame> = emptyList(),
     @SerialName("external_games") val externalGames: List<RemoteIgdbExternalGame> = emptyList(),
+)
+
+/**
+ * Row from IGDB's `/v4/game_time_to_beats` endpoint (epic #291, Phase 2). Completion times are in
+ * **seconds**; any tier IGDB lacks data for is null. Keyed by `game_id` on the request, not returned here.
+ */
+@Serializable
+data class RemoteIgdbTimeToBeat(
+    val hastily: Long? = null,
+    val normally: Long? = null,
+    val completely: Long? = null,
+    val count: Long? = null,
 )
 
 @Serializable

--- a/remote/igdb/src/commonTest/kotlin/pm/bam/gamedeals/remote/igdb/IgdbSourceImplTest.kt
+++ b/remote/igdb/src/commonTest/kotlin/pm/bam/gamedeals/remote/igdb/IgdbSourceImplTest.kt
@@ -27,6 +27,7 @@ import pm.bam.gamedeals.remote.igdb.api.IgdbGamesApi.Companion.buildSearchCandid
 import pm.bam.gamedeals.remote.igdb.api.IgdbGamesApi.Companion.buildSearchLookupDetailsQuery
 import pm.bam.gamedeals.remote.igdb.api.IgdbGamesApi.Companion.buildSteamLookupDetailsQuery
 import pm.bam.gamedeals.remote.igdb.api.IgdbGamesApi.Companion.buildSteamLookupQuery
+import pm.bam.gamedeals.remote.igdb.api.IgdbGamesApi.Companion.buildTimeToBeatQuery
 import pm.bam.gamedeals.remote.igdb.api.IgdbGamesApi.Companion.escapeApicalypseString
 import pm.bam.gamedeals.testing.TestingLoggingListener
 import pm.bam.gamedeals.testing.mockHttpClient
@@ -173,6 +174,12 @@ class IgdbSourceImplTest {
                 coverImageId = "hkco",
                 similarGames = persistentListOf(
                     IgdbGame.IgdbSimilarGame(id = 4242L, name = "Ori and the Blind Forest", coverImageId = "oco"),
+                ),
+                dlcs = persistentListOf(
+                    IgdbGame.IgdbSimilarGame(id = 9001L, name = "Hollow Knight: Hidden Dreams", coverImageId = "hdc"),
+                ),
+                expansions = persistentListOf(
+                    IgdbGame.IgdbSimilarGame(id = 9002L, name = "Hollow Knight: Godmaster", coverImageId = "gmc"),
                 ),
             ),
             result,
@@ -338,7 +345,10 @@ class IgdbSourceImplTest {
         val normalized = "Suicide Squad: Kill the Justice League"
         val recorded = mutableListOf<HttpRequestData>()
         val impl = rig(recorded) { _ ->
-            val body = if (recorded.size < 2) "[]" else ONE_GAME_DIRECT_BODY
+            // Both exact passes (decorated + normalized) must miss so the search fallback fires: the first
+            // TWO requests return empty, the THIRD (search) returns the game. (Pre-existing test bug fixed
+            // in #294 — this guard was `< 2`, which let the exact-normalized pass resolve before search.)
+            val body = if (recorded.size < 3) "[]" else ONE_GAME_DIRECT_BODY
             respond(
                 content = body,
                 status = HttpStatusCode.OK,
@@ -485,6 +495,39 @@ class IgdbSourceImplTest {
         )
     }
 
+    @Test
+    fun fetchTimeToBeat_posts_query_to_game_time_to_beats_and_maps_seconds() = runTest {
+        val recorded = mutableListOf<HttpRequestData>()
+        val impl = rig(recorded) { _ ->
+            respond(
+                content = TIME_TO_BEAT_BODY,
+                status = HttpStatusCode.OK,
+                headers = headersOf(HttpHeaders.ContentType, "application/json"),
+            )
+        }
+
+        val result = impl.fetchTimeToBeat(IGDB_ID)
+
+        assertEquals(
+            IgdbGame.IgdbTimeToBeat(hastily = 3600L, normally = 7200L, completely = 18000L, count = 1500L),
+            result,
+        )
+        val request = recorded.single()
+        assertEquals("/v4/game_time_to_beats", request.url.encodedPath)
+        assertEquals(buildTimeToBeatQuery(IGDB_ID), (request.body as TextContent).text)
+    }
+
+    @Test
+    fun fetchTimeToBeat_returns_null_when_response_is_empty_list() = runTest {
+        val recorded = mutableListOf<HttpRequestData>()
+        val impl = rig(recorded) { _ ->
+            respond(content = "[]", status = HttpStatusCode.OK, headers = headersOf(HttpHeaders.ContentType, "application/json"))
+        }
+
+        assertNull(impl.fetchTimeToBeat(IGDB_ID), "Empty list must surface as null time-to-beat")
+        assertEquals(1, recorded.size)
+    }
+
     private fun rig(
         recorded: MutableList<HttpRequestData>,
         handler: suspend MockRequestHandleScope.(HttpRequestData) -> HttpResponseData,
@@ -526,6 +569,11 @@ class IgdbSourceImplTest {
             {"id":99,"game":{"id":1,"name":"Halo Infinite","summary":"Master Chief stuff"}}
         ]"""
 
+        // language=JSON — /v4/game_time_to_beats row; times in seconds.
+        const val TIME_TO_BEAT_BODY = """[
+            {"hastily": 3600, "normally": 7200, "completely": 18000, "count": 1500}
+        ]"""
+
         // Response from `/v4/games where id = N` — flat record, no `external_games` wrapper.
         // `external_games` has only non-Steam sources here, exercising the source = 1 filter
         // (Hollow Knight ships on GOG and Itch but not Steam in this fixture, so steamAppId stays null).
@@ -538,6 +586,12 @@ class IgdbSourceImplTest {
                 "cover": {"id": 7, "image_id": "hkco"},
                 "similar_games": [
                     {"id": 4242, "name": "Ori and the Blind Forest", "cover": {"id": 8, "image_id": "oco"}}
+                ],
+                "dlcs": [
+                    {"id": 9001, "name": "Hollow Knight: Hidden Dreams", "cover": {"id": 9, "image_id": "hdc"}}
+                ],
+                "expansions": [
+                    {"id": 9002, "name": "Hollow Knight: Godmaster", "cover": {"id": 10, "image_id": "gmc"}}
                 ],
                 "external_games": [
                     {"id": 800, "uid": "hollow-knight-gog", "external_game_source": 5},


### PR DESCRIPTION
Phase 2 of the Unified Game Page epic (#291). Adds the IGDB-sourced data for the redesigned Game Page's
DLCs and HowLongToBeat sections.

## Changes
- **DLCs / expansions**: `dlcs` + `expansions` added to the IGDB detail queries (Steam-id, IGDB-id,
  exact-name, search builders), `RemoteIgdbGame`, and domain `IgdbGame` (both `ImmutableList<IgdbSimilarGame>`).
  Free with the existing games dot-expansion — no extra round-trip.
- **HowLongToBeat**: IGDB exposes completion times on the separate `/v4/game_time_to_beats` endpoint, so it
  is a **separate** `fetchTimeToBeat(igdbGameId)` (new `RemoteIgdbTimeToBeat` DTO + `IgdbGame.IgdbTimeToBeat`
  domain type, seconds). Kept off the detail fetch so an HLTB miss can't fail the game lookup — the VM
  merges it onto `IgdbGame.timeToBeat` in Phase 4. Exposed via `IgdbSource` + `IgdbRepository`.
- Mappers + tests for both; the `fetchGameDetailsByIgdbId` fixture/expectation now covers dlcs/expansions.

## Drive-by fix
`fetchGameDetailsByTitle_searches_normalized_title_when_both_exact_passes_miss` was **already failing on
`dev`** (asserts 3 requests but its MockEngine guard `recorded.size < 2` let the exact-normalized pass
resolve at request 2, before the search fallback). Corrected the guard to `< 3` to match the test's stated
intent and its own `recorded[2]` search-query assertion. Verified the failure reproduces on a clean `dev`
checkout and is unrelated to this epic.

Part of #291. Closes #294.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
