### PR TITLE
feat(game-page): repo wiring — getGameMeta + getBundlesForGame (#295)

### DIFF
--- a/domain/src/commonMain/kotlin/pm/bam/gamedeals/domain/repositories/games/GamesRepository.kt
+++ b/domain/src/commonMain/kotlin/pm/bam/gamedeals/domain/repositories/games/GamesRepository.kt
@@ -14,9 +14,11 @@ import pm.bam.gamedeals.domain.db.dao.GameDetailsCacheDao
 import pm.bam.gamedeals.domain.db.dao.GameIdMappingDao
 import pm.bam.gamedeals.domain.db.dao.GamesDao
 import pm.bam.gamedeals.domain.db.dao.PriceHistoryCacheDao
+import pm.bam.gamedeals.domain.models.Bundle
 import pm.bam.gamedeals.domain.models.Deal
 import pm.bam.gamedeals.domain.models.Game
 import pm.bam.gamedeals.domain.models.GameDetails
+import pm.bam.gamedeals.domain.models.GameMeta
 import pm.bam.gamedeals.domain.models.PriceHistory
 import pm.bam.gamedeals.domain.models.SearchParameters
 import pm.bam.gamedeals.domain.repositories.cache.CachedResource
@@ -64,6 +66,12 @@ interface GamesRepository {
     suspend fun refreshGames()
 
     suspend fun findGameIdBySteamAppId(steamAppId: Int, title: String): String?
+
+    /** Catalogue + live-signal metadata (ITAD `/games/info/v2`) for the unified Game Page — Stats tab/header (#291). */
+    suspend fun getGameMeta(gameId: String): GameMeta
+
+    /** Bundles that contain the game (ITAD `/games/bundles/v2`) for the Game Page's "Found in bundles" section (#291). */
+    suspend fun getBundlesForGame(gameId: String): List<Bundle>
 }
 
 internal class GamesRepositoryImpl(
@@ -228,4 +236,18 @@ internal class GamesRepositoryImpl(
             onFailure = { cached?.gameId },
         )
     }
+
+    /**
+     * Fetched **live** (no persistent cache) on purpose: [GameMeta] carries volatile current-player
+     * counts that a cache would stale, and bundles-for-a-game change across a bundle's lifetime. Both are
+     * per-open Game-Page fetches, bounded by the ITAD client's retry + concurrency limiter (epic #291,
+     * Phase 3). The `GamePageViewModel` treats them as best-effort enrichment (hidden on failure), so a
+     * thrown error here just hides the section. If a stable-subset cache proves worthwhile, add a
+     * short-TTL [CachedResource] like [getGameDetails].
+     */
+    override suspend fun getGameMeta(gameId: String): GameMeta =
+        dealsSource.fetchGameMeta(gameId)
+
+    override suspend fun getBundlesForGame(gameId: String): List<Bundle> =
+        dealsSource.fetchBundlesForGame(gameId)
 }

--- a/domain/src/commonTest/kotlin/pm/bam/gamedeals/domain/repositories/games/GamesRepositoryTest.kt
+++ b/domain/src/commonTest/kotlin/pm/bam/gamedeals/domain/repositories/games/GamesRepositoryTest.kt
@@ -23,7 +23,9 @@ import pm.bam.gamedeals.domain.db.dao.GameDetailsCacheDao
 import pm.bam.gamedeals.domain.db.dao.GameIdMappingDao
 import pm.bam.gamedeals.domain.db.dao.GamesDao
 import pm.bam.gamedeals.domain.db.dao.PriceHistoryCacheDao
+import pm.bam.gamedeals.domain.models.Bundle
 import pm.bam.gamedeals.domain.models.GameDetails
+import pm.bam.gamedeals.domain.models.GameMeta
 import pm.bam.gamedeals.domain.models.PriceHistory
 import pm.bam.gamedeals.domain.repositories.region.RegionRepository
 import pm.bam.gamedeals.domain.source.DealsSource
@@ -290,5 +292,46 @@ class GamesRepositoryTest {
         val result = impl.findGameIdBySteamAppId(steamAppId = 1240440, title = "Halo Infinite")
 
         assertEquals(null, result, "no stale mapping to fall back to → null")
+    }
+
+    @Test
+    fun get_game_meta_fetches_live_from_deals_source() = runTest {
+        val gameId = "uuid-1"
+        val meta = GameMeta(
+            gameId = gameId,
+            developers = persistentListOf("343 Industries"),
+            tags = persistentListOf("Shooter"),
+            players = GameMeta.Players(recent = 16763, peak = 30000),
+        )
+        everySuspend { dealsSource.fetchGameMeta(gameId) } returns meta
+
+        val result = impl.getGameMeta(gameId)
+
+        // No persistent cache (volatile player counts): always a live fetch, value passes straight through.
+        assertEquals(meta, result)
+        verifySuspend(exactly(1)) { dealsSource.fetchGameMeta(gameId) }
+    }
+
+    @Test
+    fun get_bundles_for_game_fetches_live_from_deals_source() = runTest {
+        val gameId = "uuid-1"
+        val bundles = listOf(
+            Bundle(
+                id = 16232,
+                title = "Humble Choice",
+                storeName = "Humble Bundle",
+                url = "https://humble.example/c/123",
+                expiryEpochMs = null,
+                gameCount = 8,
+                priceDenominated = "$14.99",
+                games = persistentListOf(),
+            )
+        )
+        everySuspend { dealsSource.fetchBundlesForGame(gameId) } returns bundles
+
+        val result = impl.getBundlesForGame(gameId)
+
+        assertEquals(bundles, result)
+        verifySuspend(exactly(1)) { dealsSource.fetchBundlesForGame(gameId) }
     }
 }


### PR DESCRIPTION
Phase 3 of the Unified Game Page epic (#291). Exposes the Phase 1 ITAD data through `GamesRepository` for
the Phase 4 ViewModel.

> **Stacked on #304 (Phase 1).** Base is `feat/game-page-itad-enrichment` so the diff shows only Phase 3.
> Retarget to `dev` once #304 merges.

## Changes
- `GamesRepository.getGameMeta(gameId)` and `getBundlesForGame(gameId)`, implemented in `GamesRepositoryImpl`.
- Delegation tests in `GamesRepositoryTest`.

## Caching decision (deviation from the plan note — flagging)
The Phase 3 plan suggested a `CachedResource` SWR cache. I wired these as **live fetches with no persistent
cache**, deliberately:
- `GameMeta` includes **volatile current-player counts** — a persistent cache would serve stale "playing
  now" numbers, the opposite of what that section wants.
- Bundles-for-a-game change across a bundle's lifetime.
- A persistent cache would need **new Room tables + a schema migration + migration tests** for marginal
  benefit; these are per-open fetches already bounded by the ITAD client's retry + concurrency limiter.

The `GamePageViewModel` (Phase 4) treats both as best-effort enrichment (hidden on failure), so a thrown
error just hides the section. A short-TTL cache for the *stable* subset can be a cheap follow-up if wanted.

Part of #291. Closes #295.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
